### PR TITLE
Recommendations without fallbackFilters shouldn't return random results

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Available props:
 - `indexName`: the name of the products index
 - `objectID`: the objectID of the product to get recommendations from
 - `hitComponent`: the InstantSearch-compatible `Hit` widget
-- (optional) `hitsPerPage`: the number of recommendations to retrieve (default: max recommendations available)
+- (optional) `maxRecommendations`: the number of recommendations to retrieve (default: max recommendations available)
 - (optional) `facetFilters`: additional facet filters
 - (optional) `fallbackFilters`: additional filters to use as fallback should there not be enough recommendations
 - (optional) `analytics`: whether you want Search Analytics to be turned on or not (default: `false`)
@@ -38,7 +38,7 @@ Available props:
   indexName={"your_source_index_name"}
   objectID={currentObjectID}
   hitComponent={Hit}
-  hitsPerPage={5}
+  maxRecommendations={5}
   facetFilters={[]}
   fallbackFilters={[]}
   analytics={true | false}

--- a/src/App.js
+++ b/src/App.js
@@ -42,10 +42,7 @@ class App extends Component {
         <InstantSearch indexName="gstar_demo_test" searchClient={searchClient}>
           <Configure hitsPerPage={5} />
           <h3>Looking for Recommendations?</h3>
-          <Autocomplete
-            onSuggestionSelected={this.onSuggestionSelected}
-            onSuggestionCleared={this.onSuggestionCleared}
-          />
+          <Autocomplete onSuggestionSelected={this.onSuggestionSelected} />
         </InstantSearch>
         {this.state.selectedProduct && (
           <>
@@ -56,7 +53,7 @@ class App extends Component {
               indexName={"gstar_demo_test"}
               objectID={this.state.selectedProduct.objectID}
               hitComponent={HitWithInsights}
-              hitsPerPage={3}
+              maxRecommendations={3}
               clickAnalytics={true}
               analytics={true}
             />
@@ -68,7 +65,7 @@ class App extends Component {
               indexName={"gstar_demo_test"}
               objectID={this.state.selectedProduct.objectID}
               hitComponent={HitWithInsights}
-              hitsPerPage={5}
+              maxRecommendations={5}
               facetFilters={[
                 `hierarchical_categories.lvl0:${this.state.selectedProduct.hierarchical_categories.lvl0}`,
               ]}

--- a/src/Recommendations.js
+++ b/src/Recommendations.js
@@ -39,7 +39,6 @@ const buildSearchParamsFromRecommendations_TEMPORARY_BETA = (record, props) => {
   let recoFilters = [];
   let hitsPerPage = props.hitsPerPage;
   const threshold = props.threshold || 0;
-  const model = props.model;
 
   if (record.recommendations) {
     recoFilters = record.recommendations
@@ -54,7 +53,7 @@ const buildSearchParamsFromRecommendations_TEMPORARY_BETA = (record, props) => {
       hitsPerPage = record.recommendations.length;
     }
   }
-  if (model === 'bought-together') {
+  if (this.model === 'bought-together') {
     return {
       optionalFilters: [],
       filters:

--- a/src/Recommendations.js
+++ b/src/Recommendations.js
@@ -129,10 +129,10 @@ export class Recommendations extends Component {
   }
 
   render() {
-    if (this.state.recommendations.length === 0) {
+    if (this.props.model ==="bought-together" && this.state.recommendations.length === 0) {
       return (
         <div className="text-indigo-500 text-sm text-italic">
-          No match in recommend model {this.props.model}
+          Nothing yet...
         </div>
       );
     }

--- a/src/Recommendations.js
+++ b/src/Recommendations.js
@@ -57,7 +57,14 @@ const buildSearchParamsFromRecommendations_TEMPORARY_BETA = (record, props) => {
       hitsPerPage = maxRecommendations;
     } else {
       // otherwise max the hits retrieved with maxRecommendations
-      hitsPerPage = Math.min(record.recommendations.length, maxRecommendations);
+      if (maxRecommendations > 0) {
+        hitsPerPage = Math.min(
+          record.recommendations.length,
+          maxRecommendations
+        );
+      } else {
+        hitsPerPage = record.recommendations.length;
+      }
     }
   } else {
     recoFilters = [];

--- a/src/Recommendations.js
+++ b/src/Recommendations.js
@@ -59,7 +59,7 @@ const buildSearchParamsFromRecommendations_TEMPORARY_BETA = (record, props) => {
       optionalFilters: [],
       filters:
         (recoFilters.length > 0 &&
-          composeFilters(recoFilters, props.objectID)) ||
+          composeFilters(recoFilters)) ||
         null,
       facetFilters: (recoFilters.length > 0 && props.facetFilters) || [],
       hitsPerPage,

--- a/src/Recommendations.js
+++ b/src/Recommendations.js
@@ -33,13 +33,7 @@ const getRecommendedObject_TEMPORARY_BETA = (
     });
 };
 
-const composeFilters = (recoFilters) => {
-  let compose = '';
-  if (recoFilters.length > 0) {
-    compose += `(${recoFilters.join(' OR ')})`;
-  }
-  return compose;
-};
+const composeFilters = (recoFilters) => recoFilters.length ? `(${recoFilters.join(' OR ')})` : '';
 
 const buildSearchParamsFromRecommendations_TEMPORARY_BETA = (record, props) => {
   let recoFilters = [];


### PR DESCRIPTION
As of today, the `hitsPerPage` prop is driving the number of recommendation we display; whatever the number of recommendation we actually get and whether or not you have fallback filters.

Especially for Bought Together; you rather don't want any results than random hits, should you not have any recommendations.