### PR TITLE
fix(types): fix missing types

### DIFF
--- a/packages/react-recommendations/src/FrequentlyBoughtTogether.tsx
+++ b/packages/react-recommendations/src/FrequentlyBoughtTogether.tsx
@@ -13,7 +13,8 @@ import {
 
 export type FrequentlyBoughtTogetherProps<
   TObject
-> = UseFrequentlyBoughtTogetherProps & RecommendationsComponentProps<TObject>;
+> = UseFrequentlyBoughtTogetherProps<TObject> &
+  RecommendationsComponentProps<TObject>;
 
 export function FrequentlyBoughtTogether<TObject>(
   props: FrequentlyBoughtTogetherProps<TObject>

--- a/packages/react-recommendations/src/RelatedProducts.tsx
+++ b/packages/react-recommendations/src/RelatedProducts.tsx
@@ -11,7 +11,7 @@ import {
   UseRelatedProductsProps,
 } from './useRelatedProducts';
 
-export type RelatedProductsProps<TObject> = UseRelatedProductsProps &
+export type RelatedProductsProps<TObject> = UseRelatedProductsProps<TObject> &
   RecommendationsComponentProps<TObject>;
 
 export function RelatedProducts<TObject>(props: RelatedProductsProps<TObject>) {

--- a/packages/react-recommendations/src/types/RecommendationTranslations.ts
+++ b/packages/react-recommendations/src/types/RecommendationTranslations.ts
@@ -1,4 +1,4 @@
-export type RecommendationTranslations = {
+export type RecommendationTranslations = Partial<{
   title: string;
   showMore: string;
-};
+}>;

--- a/packages/react-recommendations/src/types/RecommendationsComponentProps.ts
+++ b/packages/react-recommendations/src/types/RecommendationsComponentProps.ts
@@ -11,7 +11,7 @@ export type ChildrenProps<TObject> = {
 export type RecommendationsComponentProps<TObject> = {
   itemComponent({ item: TObject }): JSX.Element;
   children?(props: ChildrenProps<TObject>): JSX.Element;
-  translations?: Partial<RecommendationTranslations>;
+  translations?: RecommendationTranslations;
   view?(
     props: ViewProps<
       RecordWithObjectID<TObject>,

--- a/packages/react-recommendations/src/useFrequentlyBoughtTogether.ts
+++ b/packages/react-recommendations/src/useFrequentlyBoughtTogether.ts
@@ -1,5 +1,3 @@
-import type { SearchOptions } from '@algolia/client-search';
-import type { SearchClient } from 'algoliasearch';
 import { useMemo } from 'react';
 
 import {
@@ -7,18 +5,13 @@ import {
   UseRecommendationsProps,
 } from './useRecommendations';
 
-export type UseFrequentlyBoughtTogetherProps = {
-  indexName: string;
-  objectIDs: string[];
-  searchClient: SearchClient;
-
-  maxRecommendations?: number;
-  searchParameters?: SearchOptions;
-  threshold?: number;
-};
+export type UseFrequentlyBoughtTogetherProps<TObject> = Omit<
+  UseRecommendationsProps<TObject>,
+  'model' | 'fallbackFilters'
+>;
 
 export function useFrequentlyBoughtTogether<TObject>(
-  userProps: UseFrequentlyBoughtTogetherProps
+  userProps: UseFrequentlyBoughtTogetherProps<TObject>
 ) {
   const props: UseRecommendationsProps<TObject> = useMemo(
     () => ({

--- a/packages/react-recommendations/src/useRelatedProducts.ts
+++ b/packages/react-recommendations/src/useRelatedProducts.ts
@@ -1,5 +1,3 @@
-import type { SearchOptions } from '@algolia/client-search';
-import type { SearchClient } from 'algoliasearch';
 import { useMemo } from 'react';
 
 import {
@@ -7,19 +5,13 @@ import {
   UseRecommendationsProps,
 } from './useRecommendations';
 
-export type UseRelatedProductsProps = {
-  indexName: string;
-  objectIDs: string[];
-  searchClient: SearchClient;
-
-  fallbackFilters?: SearchOptions['optionalFilters'];
-  maxRecommendations?: number;
-  searchParameters?: SearchOptions;
-  threshold?: number;
-};
+export type UseRelatedProductsProps<TObject> = Omit<
+  UseRecommendationsProps<TObject>,
+  'model'
+>;
 
 export function useRelatedProducts<TObject>(
-  userProps: UseRelatedProductsProps
+  userProps: UseRelatedProductsProps<TObject>
 ) {
   const props: UseRecommendationsProps<TObject> = useMemo(
     () => ({


### PR DESCRIPTION
**Summary** 

- Export correct types for `RecommendationTranslations`.
- Initialize hooks types from `UseRecommendationsProps` which solves the missing declaration of `transformItems`.

**Result**
Exported types should now be correct