### PR TITLE
feat(recommendations): support `classNames` prop

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -6,7 +6,7 @@
     },
     {
       "path": "packages/js-recommendations/dist/umd/index.js",
-      "maxSize": "8.25 kB"
+      "maxSize": "8.5 kB"
     },
     {
       "path": "packages/react-horizontal-slider/dist/umd/index.js",
@@ -14,7 +14,7 @@
     },
     {
       "path": "packages/react-recommendations/dist/umd/index.js",
-      "maxSize": "2.5 kB"
+      "maxSize": "2.75 kB"
     }
   ]
 }

--- a/packages/js-recommendations/README.md
+++ b/packages/js-recommendations/README.md
@@ -120,8 +120,9 @@ The translations for the component.
 
 ```ts
 type ChildrenProps<TObject> = {
+  classNames: RecommendationClassNames;
   recommendations: TObject[];
-  translations: RecommendationTranslations;
+  translations: Required<RecommendationTranslations>;
   View(props: unknown): JSX.Element;
 };
 ```
@@ -257,8 +258,9 @@ The translations for the component.
 
 ```ts
 type ChildrenProps<TObject> = {
+  classNames: RecommendationClassNames;
   recommendations: TObject[];
-  translations: RelatedProductTranslations;
+  translations: Required<RecommendationTranslations>;
   View(props: unknown): JSX.Element;
 };
 ```

--- a/packages/js-recommendations/README.md
+++ b/packages/js-recommendations/README.md
@@ -70,6 +70,28 @@ The container for the `relatedProducts` component. You can either pass a [CSS se
 
 The product component to display.
 
+##### `classNames`
+
+<blockquote>
+<details>
+
+<summary><code>RelatedProductsClassNames</code></summary>
+
+```ts
+type RelatedProductsClassNames = Partial<{
+  root: string;
+  title: string;
+  container: string;
+  list: string;
+  item: string;
+}>;
+```
+
+</details>
+</blockquote>
+
+The class names for the component.
+
 ##### `translations`
 
 <blockquote>
@@ -184,6 +206,28 @@ The container for the `frequentlyBoughtTogether` component. You can either pass 
 > `({ item }) => JSX.Element` | **required**
 
 The product component to display.
+
+##### `classNames`
+
+<blockquote>
+<details>
+
+<summary><code>FrequentlyBoughtTogetherClassNames</code></summary>
+
+```ts
+type FrequentlyBoughtTogetherClassNames = Partial<{
+  root: string;
+  title: string;
+  container: string;
+  list: string;
+  item: string;
+}>;
+```
+
+</details>
+</blockquote>
+
+The class names for the component.
 
 ##### `translations`
 

--- a/packages/react-recommendations/README.md
+++ b/packages/react-recommendations/README.md
@@ -189,8 +189,9 @@ function ListView(props) {
 
 ```ts
 type ChildrenProps<TObject> = {
+  classNames: RecommendationClassNames;
   recommendations: TObject[];
-  translations: RelatedProductTranslations;
+  translations: Required<RecommendationTranslations>;
   View(props: unknown): JSX.Element;
 };
 ```
@@ -446,8 +447,9 @@ function ListView(props) {
 
 ```ts
 type ChildrenProps<TObject> = {
+  classNames: RecommendationClassNames;
   recommendations: TObject[];
-  translations: RecommendationTranslations;
+  translations: Required<RecommendationTranslations>;
   View(props: unknown): JSX.Element;
 };
 ```

--- a/packages/react-recommendations/README.md
+++ b/packages/react-recommendations/README.md
@@ -100,6 +100,28 @@ The component accepts all the [shared props](#shared-props) and the following:
 
 The product component to display.
 
+#### `classNames`
+
+<blockquote>
+<details>
+
+<summary><code>RelatedProductsClassNames</code></summary>
+
+```ts
+type RelatedProductsClassNames = Partial<{
+  root: string;
+  title: string;
+  container: string;
+  list: string;
+  item: string;
+}>;
+```
+
+</details>
+</blockquote>
+
+The class names for the component.
+
 #### `translations`
 
 <blockquote>
@@ -120,6 +142,43 @@ type RelatedProductTranslations = Partial<{
 The translations for the component.
 
 </details>
+
+#### `view`
+
+<blockquote>
+<details>
+
+<summary><code>(props: ViewProps) => JSX.Element</code></summary>
+
+```ts
+type ViewProps<TItem extends RecordWithObjectID> = {
+  items: TItem[];
+  itemComponent({ item: TItem }): JSX.Element;
+};
+```
+
+</details>
+</blockquote>
+
+The view component to render your items into. You can use the [`HorizontalSlider`](/packages/react-horizontal-slider) UI component.
+
+The default implementation is:
+
+```js
+function ListView(props) {
+  return (
+    <div className="auc-Recommendations-container">
+      <ol className="auc-Recommendations-list">
+        {props.items.map((item) => (
+          <li key={item.objectID} className="auc-Recommendations-item">
+            <props.itemComponent item={item} />
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}
+```
 
 #### `children`
 
@@ -155,43 +214,6 @@ function defaultRender(props) {
 
       <props.View />
     </section>
-  );
-}
-```
-
-#### `view`
-
-<blockquote>
-<details>
-
-<summary><code>(props: ViewProps) => JSX.Element</code></summary>
-
-```ts
-type ViewProps<TItem extends RecordWithObjectID> = {
-  items: TItem[];
-  itemComponent({ item: TItem }): JSX.Element;
-};
-```
-
-</details>
-</blockquote>
-
-The view component to render your items into. You can use the [`HorizontalSlider`](/packages/react-horizontal-slider) UI component.
-
-The default implementation is:
-
-```js
-function ListView(props) {
-  return (
-    <div className="auc-Recommendations-container">
-      <ol className="auc-Recommendations-list">
-        {props.items.map((item) => (
-          <li key={item.objectID} className="auc-Recommendations-item">
-            <props.itemComponent item={item} />
-          </li>
-        ))}
-      </ol>
-    </div>
   );
 }
 ```
@@ -337,6 +359,28 @@ The component accepts all the [shared props](#shared-props) and the following:
 
 The product component to display.
 
+#### `classNames`
+
+<blockquote>
+<details>
+
+<summary><code>FrequentlyBoughtTogetherClassNames</code></summary>
+
+```ts
+type FrequentlyBoughtTogetherClassNames = Partial<{
+  root: string;
+  title: string;
+  container: string;
+  list: string;
+  item: string;
+}>;
+```
+
+</details>
+</blockquote>
+
+The class names for the component.
+
 #### `translations`
 
 <blockquote>
@@ -355,6 +399,43 @@ type FrequentlyBoughtTogetherTranslations = Partial<{
 </blockquote>
 
 The translations for the component.
+
+#### `view`
+
+<blockquote>
+<details>
+
+<summary><code>(props: ViewProps) => JSX.Element</code></summary>
+
+```ts
+type ViewProps<TItem extends RecordWithObjectID> = {
+  items: TItem[];
+  itemComponent({ item: TItem }): JSX.Element;
+};
+```
+
+</details>
+</blockquote>
+
+The view component to render your items into. You can use the [`HorizontalSlider`](/packages/react-horizontal-slider) UI component.
+
+The default implementation is:
+
+```js
+function ListView(props) {
+  return (
+    <div className="auc-Recommendations-container">
+      <ol className="auc-Recommendations-list">
+        {props.items.map((item) => (
+          <li key={item.objectID} className="auc-Recommendations-item">
+            <props.itemComponent item={item} />
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}
+```
 
 #### `children`
 
@@ -390,43 +471,6 @@ function defaultRender(props) {
 
       <props.View />
     </section>
-  );
-}
-```
-
-#### `view`
-
-<blockquote>
-<details>
-
-<summary><code>(props: ViewProps) => JSX.Element</code></summary>
-
-```ts
-type ViewProps<TItem extends RecordWithObjectID> = {
-  items: TItem[];
-  itemComponent({ item: TItem }): JSX.Element;
-};
-```
-
-</details>
-</blockquote>
-
-The view component to render your items into. You can use the [`HorizontalSlider`](/packages/react-horizontal-slider) UI component.
-
-The default implementation is:
-
-```js
-function ListView(props) {
-  return (
-    <div className="auc-Recommendations-container">
-      <ol className="auc-Recommendations-list">
-        {props.items.map((item) => (
-          <li key={item.objectID} className="auc-Recommendations-item">
-            <props.itemComponent item={item} />
-          </li>
-        ))}
-      </ol>
-    </div>
   );
 }
 ```

--- a/packages/react-recommendations/src/FrequentlyBoughtTogether.tsx
+++ b/packages/react-recommendations/src/FrequentlyBoughtTogether.tsx
@@ -10,6 +10,7 @@ import {
   useFrequentlyBoughtTogether,
   UseFrequentlyBoughtTogetherProps,
 } from './useFrequentlyBoughtTogether';
+import { cx } from './utils';
 
 export type FrequentlyBoughtTogetherProps<
   TObject
@@ -20,7 +21,7 @@ export function FrequentlyBoughtTogether<TObject>(
   props: FrequentlyBoughtTogetherProps<TObject>
 ) {
   const { recommendations } = useFrequentlyBoughtTogether<TObject>(props);
-  const translations = useMemo<RecommendationTranslations>(
+  const translations = useMemo<Required<RecommendationTranslations>>(
     () => ({
       title: 'Frequently bought together',
       sliderLabel: 'Frequently bought together products',
@@ -29,11 +30,13 @@ export function FrequentlyBoughtTogether<TObject>(
     }),
     [props.translations]
   );
+  const classNames = props.classNames ?? {};
 
   const render = props.children ?? defaultRender;
   const ViewComponent = props.view ?? ListView;
   const View = (viewProps: unknown) => (
     <ViewComponent
+      classNames={classNames}
       items={recommendations}
       itemComponent={props.itemComponent}
       translations={translations}
@@ -41,7 +44,7 @@ export function FrequentlyBoughtTogether<TObject>(
     />
   );
 
-  return render({ recommendations, translations, View });
+  return render({ classNames, recommendations, translations, View });
 }
 
 function defaultRender<TObject>(props: ChildrenProps<TObject>) {
@@ -50,8 +53,12 @@ function defaultRender<TObject>(props: ChildrenProps<TObject>) {
   }
 
   return (
-    <section className="auc-Recommendations">
-      {props.translations.title && <h3>{props.translations.title}</h3>}
+    <section className={cx('auc-Recommendations', props.classNames.root)}>
+      {props.translations.title && (
+        <h3 className={cx('auc-Recommendations-title', props.classNames.title)}>
+          {props.translations.title}
+        </h3>
+      )}
 
       <props.View />
     </section>

--- a/packages/react-recommendations/src/ListView.tsx
+++ b/packages/react-recommendations/src/ListView.tsx
@@ -1,15 +1,29 @@
 import React from 'react';
 
-import { RecordWithObjectID, ViewProps } from './types';
+import {
+  RecommendationClassNames,
+  RecommendationTranslations,
+  RecordWithObjectID,
+  ViewProps,
+} from './types';
+import { cx } from './utils';
 
 export function ListView<TItem extends RecordWithObjectID>(
-  props: ViewProps<TItem, {}, {}>
+  props: ViewProps<TItem, RecommendationTranslations, RecommendationClassNames>
 ) {
   return (
-    <div className="auc-Recommendations-container">
-      <ol className="auc-Recommendations-list">
+    <div
+      className={cx(
+        'auc-Recommendations-container',
+        props.classNames.container
+      )}
+    >
+      <ol className={cx('auc-Recommendations-list', props.classNames.list)}>
         {props.items.map((item) => (
-          <li key={item.objectID} className="auc-Recommendations-item">
+          <li
+            key={item.objectID}
+            className={cx('auc-Recommendations-item', props.classNames.item)}
+          >
             <props.itemComponent item={item} />
           </li>
         ))}

--- a/packages/react-recommendations/src/RelatedProducts.tsx
+++ b/packages/react-recommendations/src/RelatedProducts.tsx
@@ -10,13 +10,14 @@ import {
   useRelatedProducts,
   UseRelatedProductsProps,
 } from './useRelatedProducts';
+import { cx } from './utils';
 
 export type RelatedProductsProps<TObject> = UseRelatedProductsProps<TObject> &
   RecommendationsComponentProps<TObject>;
 
 export function RelatedProducts<TObject>(props: RelatedProductsProps<TObject>) {
   const { recommendations } = useRelatedProducts<TObject>(props);
-  const translations = useMemo<RecommendationTranslations>(
+  const translations = useMemo<Required<RecommendationTranslations>>(
     () => ({
       title: 'Related products',
       sliderLabel: 'Related products',
@@ -25,11 +26,13 @@ export function RelatedProducts<TObject>(props: RelatedProductsProps<TObject>) {
     }),
     [props.translations]
   );
+  const classNames = props.classNames ?? {};
 
   const render = props.children ?? defaultRender;
   const ViewComponent = props.view ?? ListView;
   const View = (viewProps: unknown) => (
     <ViewComponent
+      classNames={classNames}
       items={recommendations}
       itemComponent={props.itemComponent}
       translations={translations}
@@ -37,7 +40,7 @@ export function RelatedProducts<TObject>(props: RelatedProductsProps<TObject>) {
     />
   );
 
-  return render({ recommendations, translations, View });
+  return render({ classNames, recommendations, translations, View });
 }
 
 function defaultRender<TObject>(props: ChildrenProps<TObject>) {
@@ -46,8 +49,12 @@ function defaultRender<TObject>(props: ChildrenProps<TObject>) {
   }
 
   return (
-    <section className="auc-Recommendations">
-      {props.translations.title && <h3>{props.translations.title}</h3>}
+    <section className={cx('auc-Recommendations', props.classNames.root)}>
+      {props.translations.title && (
+        <h3 className={cx('auc-Recommendations-title', props.classNames.title)}>
+          {props.translations.title}
+        </h3>
+      )}
 
       <props.View />
     </section>

--- a/packages/react-recommendations/src/types/RecommendationClassNames.ts
+++ b/packages/react-recommendations/src/types/RecommendationClassNames.ts
@@ -1,0 +1,7 @@
+export type RecommendationClassNames = Partial<{
+  root: string;
+  title: string;
+  container: string;
+  list: string;
+  item: string;
+}>;

--- a/packages/react-recommendations/src/types/RecommendationsComponentProps.ts
+++ b/packages/react-recommendations/src/types/RecommendationsComponentProps.ts
@@ -1,21 +1,24 @@
+import { RecommendationClassNames } from './RecommendationClassNames';
 import { RecommendationTranslations } from './RecommendationTranslations';
 import { RecordWithObjectID } from './RecordWithObjectID';
 import { ViewProps } from './ViewProps';
 
 export type ChildrenProps<TObject> = {
+  classNames: RecommendationClassNames;
   recommendations: TObject[];
+  translations: Required<RecommendationTranslations>;
   View(props: unknown): JSX.Element;
-  translations: RecommendationTranslations;
 };
 
 export type RecommendationsComponentProps<TObject> = {
   itemComponent({ item: TObject }): JSX.Element;
+  classNames?: RecommendationClassNames;
   children?(props: ChildrenProps<TObject>): JSX.Element;
-  translations?: RecommendationTranslations;
+  translations?: Required<RecommendationTranslations>;
   view?(
     props: ViewProps<
       RecordWithObjectID<TObject>,
-      RecommendationTranslations,
+      Required<RecommendationTranslations>,
       Record<string, string>
     >
   ): JSX.Element;

--- a/packages/react-recommendations/src/types/ViewProps.ts
+++ b/packages/react-recommendations/src/types/ViewProps.ts
@@ -5,8 +5,8 @@ export type ViewProps<
   TTranslations extends Record<string, string>,
   TClassNames extends Record<string, string>
 > = {
-  items: TItem[];
+  classNames: TClassNames;
   itemComponent({ item: TItem }): JSX.Element;
-  classNames?: Partial<TClassNames>;
-  translations?: Partial<TTranslations>;
+  items: TItem[];
+  translations: TTranslations;
 };

--- a/packages/react-recommendations/src/types/index.ts
+++ b/packages/react-recommendations/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from './ProductRecord';
+export * from './RecommendationClassNames';
 export * from './RecommendationModel';
 export * from './RecommendationRecord';
 export * from './RecommendationsComponentProps';

--- a/packages/react-recommendations/src/utils/cx.ts
+++ b/packages/react-recommendations/src/utils/cx.ts
@@ -1,0 +1,3 @@
+export function cx(...classNames: Array<string | undefined>) {
+  return classNames.filter(Boolean).join(' ');
+}

--- a/packages/react-recommendations/src/utils/index.ts
+++ b/packages/react-recommendations/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './cx';
 export * from './getHitsPerPage';
 export * from './getIndexNameFromModel';
 export * from './getOptionalFilters';


### PR DESCRIPTION
This adds support for the `classNames` prop in the `FrequentlyBoughtTogether` and `RelatedProducts` components. This prop is useful to style components based on CSS tools like Tailwind.