### PR TITLE
feat(recommendations): add `fallbackComponent` prop

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "packages/react-recommendations/dist/umd/index.js",
-      "maxSize": "2.75 kB"
+      "maxSize": "3 kB"
     }
   ]
 }

--- a/examples/demo/src/App.js
+++ b/examples/demo/src/App.js
@@ -24,6 +24,10 @@ const searchClient = algoliasearch(appId, apiKey);
 
 insights('init', { appId, apiKey });
 
+function RecommendedItem({ item }) {
+  return <Hit hit={item} insights={insights} />;
+}
+
 function App() {
   const [selectedProduct, setSelectedProduct] = useState(null);
 
@@ -121,41 +125,42 @@ function App() {
             searchClient={searchClient}
             indexName={indexName}
             objectIDs={[selectedProduct.objectID]}
-            itemComponent={({ item }) => <Hit hit={item} insights={insights} />}
+            itemComponent={RecommendedItem}
             maxRecommendations={3}
             searchParameters={{
               analytics: true,
               clickAnalytics: true,
             }}
+            fallbackComponent={() => (
+              <RelatedProducts
+                searchClient={searchClient}
+                indexName={indexName}
+                objectIDs={[selectedProduct.objectID]}
+                itemComponent={RecommendedItem}
+                view={HorizontalSlider}
+                maxRecommendations={10}
+                translations={{
+                  title: 'Related products (fallback)',
+                }}
+                fallbackFilters={[
+                  `hierarchical_categories.lvl2:${selectedProduct.hierarchical_categories.lvl2}`,
+                ]}
+                searchParameters={{
+                  analytics: true,
+                  clickAnalytics: true,
+                  facetFilters: [
+                    `hierarchical_categories.lvl0:${selectedProduct.hierarchical_categories.lvl0}`,
+                  ],
+                }}
+              />
+            )}
           />
 
           <RelatedProducts
             searchClient={searchClient}
             indexName={indexName}
             objectIDs={[selectedProduct.objectID]}
-            itemComponent={({ item }) => <Hit hit={item} insights={insights} />}
-            view={HorizontalSlider}
-            maxRecommendations={10}
-            translations={{
-              title: 'Related products (slider)',
-            }}
-            fallbackFilters={[
-              `hierarchical_categories.lvl2:${selectedProduct.hierarchical_categories.lvl2}`,
-            ]}
-            searchParameters={{
-              analytics: true,
-              clickAnalytics: true,
-              facetFilters: [
-                `hierarchical_categories.lvl0:${selectedProduct.hierarchical_categories.lvl0}`,
-              ],
-            }}
-          />
-
-          <RelatedProducts
-            searchClient={searchClient}
-            indexName={indexName}
-            objectIDs={[selectedProduct.objectID]}
-            itemComponent={({ item }) => <Hit hit={item} insights={insights} />}
+            itemComponent={RecommendedItem}
             maxRecommendations={10}
             translations={{
               title: 'Related products',

--- a/packages/react-recommendations/src/DefaultChildren.tsx
+++ b/packages/react-recommendations/src/DefaultChildren.tsx
@@ -5,7 +5,7 @@ import { cx } from './utils';
 
 export function DefaultChildren<TObject>(props: ChildrenProps<TObject>) {
   if (props.recommendations.length === 0) {
-    return null;
+    return <props.Fallback />;
   }
 
   return (

--- a/packages/react-recommendations/src/DefaultFallback.tsx
+++ b/packages/react-recommendations/src/DefaultFallback.tsx
@@ -1,0 +1,3 @@
+export function DefaultFallback() {
+  return null;
+}

--- a/packages/react-recommendations/src/FrequentlyBoughtTogether.tsx
+++ b/packages/react-recommendations/src/FrequentlyBoughtTogether.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 
 import { DefaultChildren } from './DefaultChildren';
 import { DefaultFallback } from './DefaultFallback';

--- a/packages/react-recommendations/src/FrequentlyBoughtTogether.tsx
+++ b/packages/react-recommendations/src/FrequentlyBoughtTogether.tsx
@@ -1,6 +1,7 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import { DefaultChildren } from './DefaultChildren';
+import { DefaultFallback } from './DefaultFallback';
 import { DefaultHeader } from './DefaultHeader';
 import { ListView } from './ListView';
 import {
@@ -33,6 +34,7 @@ export function FrequentlyBoughtTogether<TObject>(
   const classNames = props.classNames ?? {};
 
   const children = props.children ?? DefaultChildren;
+  const Fallback = props.fallbackComponent ?? DefaultFallback;
   const Header = props.headerComponent ?? DefaultHeader;
   const ViewComponent = props.view ?? ListView;
   const View = (viewProps: unknown) => (
@@ -45,5 +47,12 @@ export function FrequentlyBoughtTogether<TObject>(
     />
   );
 
-  return children({ classNames, Header, recommendations, translations, View });
+  return children({
+    classNames,
+    Fallback,
+    Header,
+    recommendations,
+    translations,
+    View,
+  });
 }

--- a/packages/react-recommendations/src/RelatedProducts.tsx
+++ b/packages/react-recommendations/src/RelatedProducts.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 
 import { DefaultChildren } from './DefaultChildren';
+import { DefaultFallback } from './DefaultFallback';
 import { DefaultHeader } from './DefaultHeader';
 import { ListView } from './ListView';
 import {
@@ -29,6 +30,7 @@ export function RelatedProducts<TObject>(props: RelatedProductsProps<TObject>) {
   const classNames = props.classNames ?? {};
 
   const children = props.children ?? DefaultChildren;
+  const Fallback = props.fallbackComponent ?? DefaultFallback;
   const Header = props.headerComponent ?? DefaultHeader;
   const ViewComponent = props.view ?? ListView;
   const View = (viewProps: unknown) => (
@@ -41,5 +43,12 @@ export function RelatedProducts<TObject>(props: RelatedProductsProps<TObject>) {
     />
   );
 
-  return children({ classNames, Header, recommendations, translations, View });
+  return children({
+    classNames,
+    Fallback,
+    Header,
+    recommendations,
+    translations,
+    View,
+  });
 }

--- a/packages/react-recommendations/src/types/RecommendationsComponentProps.ts
+++ b/packages/react-recommendations/src/types/RecommendationsComponentProps.ts
@@ -10,6 +10,7 @@ export type ComponentProps<TObject> = {
 };
 
 export type ChildrenProps<TObject> = ComponentProps<TObject> & {
+  Fallback(): JSX.Element | null;
   Header(props: ComponentProps<TObject>): JSX.Element | null;
   View(props: unknown): JSX.Element;
 };
@@ -18,6 +19,7 @@ export type RecommendationsComponentProps<TObject> = {
   itemComponent({ item: TObject }): JSX.Element;
   classNames?: RecommendationClassNames;
   children?(props: ChildrenProps<TObject>): JSX.Element;
+  fallbackComponent?(): JSX.Element;
   headerComponent?(props: ComponentProps<TObject>): JSX.Element;
   translations?: Required<RecommendationTranslations>;
   view?(


### PR DESCRIPTION
This introduces a new prop called `fallbackComponent` that is called when no recommendations are returned by the engine.

A pattern that we want to encourage is to display Related Products when there's no FBT, as seen in the demo.