### PR TITLE
docs(fbt): add FBT bundle view

### DIFF
--- a/examples/demo/src/App.js
+++ b/examples/demo/src/App.js
@@ -10,6 +10,7 @@ import insights from 'search-insights';
 import '@algolia/autocomplete-theme-classic';
 
 import { Autocomplete, getAlgoliaResults } from './Autocomplete';
+import { BundleView } from './BundleView';
 import { Hit } from './Hit';
 
 import '@algolia/ui-components-react-horizontal-slider/HorizontalSlider.css';
@@ -26,6 +27,30 @@ insights('init', { appId, apiKey });
 
 function RecommendedItem({ item }) {
   return <Hit hit={item} insights={insights} />;
+}
+
+function BundleItem({ item }) {
+  return (
+    <a
+      className="Hit Hit-link"
+      href={item.url}
+      onClick={(event) => {
+        event.preventDefault();
+
+        insights('clickedObjectIDs', {
+          objectIDs: [item.objectID],
+          positions: [item.__position],
+          eventName: 'Product Clicked',
+          queryID: item.__queryID,
+          index: item.__indexName,
+        });
+      }}
+    >
+      <div className="Hit-Image">
+        <img src={item.image_link} alt={item.name} />
+      </div>
+    </a>
+  );
 }
 
 function App() {
@@ -125,12 +150,15 @@ function App() {
             searchClient={searchClient}
             indexName={indexName}
             objectIDs={[selectedProduct.objectID]}
-            itemComponent={RecommendedItem}
-            maxRecommendations={3}
+            itemComponent={BundleItem}
+            maxRecommendations={2}
             searchParameters={{
               analytics: true,
               clickAnalytics: true,
             }}
+            view={(props) => (
+              <BundleView {...props} currentItem={selectedProduct} />
+            )}
             fallbackComponent={() => (
               <RelatedProducts
                 searchClient={searchClient}

--- a/examples/demo/src/BundleView.css
+++ b/examples/demo/src/BundleView.css
@@ -1,0 +1,87 @@
+.uic-BundleView-container {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 3fr 1fr;
+}
+
+.uic-BundleView-list {
+  display: grid;
+  gap: 0.5rem;
+  grid-auto-flow: column;
+  list-style: none;
+  margin: 0;
+  outline-color: var(--aui-primary-color);
+  outline-offset: 0.5rem;
+  padding: 0;
+  padding-bottom: 0.5rem;
+}
+
+.uic-BundleView-itemContainer {
+  align-items: center;
+  display: flex;
+}
+
+.uic-BundleView-itemContainer-hit {
+  opacity: 0.4;
+}
+
+.uic-BundleView-item--selected .uic-BundleView-itemContainer-hit {
+  opacity: 1;
+}
+
+.uic-BundleView-itemContainer {
+  align-items: center;
+  display: flex;
+}
+
+.uic-BundleView-plus {
+  color: #5468ff;
+  padding-left: 0.5rem;
+}
+
+.uic-BundleView-plus > svg {
+  height: 24px;
+  width: 24px;
+}
+
+.uic-BundleView-item * {
+  outline-color: var(--aui-primary-color);
+  outline-offset: 3px;
+}
+
+.uic-BundleView-label {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.uic-BundleView-label:hover {
+  color: #5468ff;
+}
+
+.uic-BundleView-label-currentArticle,
+.uic-BundleView-label-price {
+  font-weight: bold;
+}
+
+.uic-BundleView-cart {
+  align-items: start;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  justify-content: center;
+}
+
+.uic-BundleView-addToCart {
+  align-items: center;
+  background: #fff;
+  border: 1px solid #5468ff;
+  border-radius: 4px;
+  color: #141d61;
+  cursor: pointer;
+  display: flex;
+  font-weight: 600;
+  justify-content: center;
+  padding: 0;
+  padding: 6px;
+  position: relative;
+}

--- a/examples/demo/src/BundleView.js
+++ b/examples/demo/src/BundleView.js
@@ -1,0 +1,141 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
+import './BundleView.css';
+
+function getAmountDefault(items) {
+  return items.reduce((sum, current) => sum + current.price, 0);
+}
+
+function formatPriceDefault(price) {
+  return `$${price}`;
+}
+
+export function BundleView(props) {
+  const items = [props.currentItem, ...props.items];
+  const formatPrice = props.formatPrice ?? formatPriceDefault;
+  const getAmount = props.getAmount ?? getAmountDefault;
+
+  const [selectedItems, setSelectedItems] = useState(() => items);
+  const [price, setPrice] = useState(() => getAmount(selectedItems));
+  const translations = useMemo(
+    () => ({
+      totalPrice: 'Total price',
+      thisArticle: 'This article',
+      addToCart: (count) => {
+        if (count === 1) {
+          return `Add ${count} product to cart`;
+        }
+
+        return `Add ${count} products to cart`;
+      },
+      ...props.translations,
+    }),
+    [props.translations]
+  );
+
+  useEffect(() => {
+    setPrice(getAmount(selectedItems));
+  }, [selectedItems]);
+
+  return (
+    <div className="uic-BundleView-container">
+      <div className="uic-BundleView-items">
+        <ol className="uic-BundleView-list">
+          {items.map((item, index) => {
+            const isSelected = Boolean(
+              selectedItems.find((x) => x.objectID === item.objectID)
+            );
+
+            function onChange(event) {
+              setSelectedItems((items) =>
+                event.target.checked
+                  ? [...items, item]
+                  : items.filter((x) => x.objectID !== item.objectID)
+              );
+            }
+
+            return (
+              <li
+                key={item.objectID}
+                className={[
+                  'uic-BundleView-item',
+                  isSelected && 'uic-BundleView-item--selected',
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+              >
+                <div className="uic-BundleView-itemContainer">
+                  <div className="uic-BundleView-itemContainer-hit">
+                    <props.itemComponent item={item} />
+                  </div>
+                  {index < items.length - 1 && (
+                    <div className="uic-BundleView-plus">
+                      <svg viewBox="0 0 24 24" fill="none">
+                        <rect
+                          width="24"
+                          height="24"
+                          rx="12"
+                          fill="currentColor"
+                        />
+                        <path
+                          fillRule="evenodd"
+                          clipRule="evenodd"
+                          d="M12 5.54169C12.3452 5.54169 12.625 5.82151 12.625 6.16669V17.8334C12.625 18.1785 12.3452 18.4584 12 18.4584C11.6548 18.4584 11.375 18.1785 11.375 17.8334V6.16669C11.375 5.82151 11.6548 5.54169 12 5.54169Z"
+                          fill="#fff"
+                          stroke="#fff"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                        <path
+                          fillRule="evenodd"
+                          clipRule="evenodd"
+                          d="M5.54166 12C5.54166 11.6548 5.82148 11.375 6.16666 11.375H17.8333C18.1785 11.375 18.4583 11.6548 18.4583 12C18.4583 12.3452 18.1785 12.625 17.8333 12.625H6.16666C5.82148 12.625 5.54166 12.3452 5.54166 12Z"
+                          fill="#fff"
+                          stroke="#fff"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                      </svg>
+                    </div>
+                  )}
+                </div>
+
+                <label className="uic-BundleView-label">
+                  <input
+                    className="uic-BundleView-checkbox"
+                    type="checkbox"
+                    defaultChecked={isSelected}
+                    onChange={onChange}
+                  />
+                  {item.objectID === props.currentItem.objectID && (
+                    <span className="uic-BundleView-label-currentArticle">
+                      {translations.thisArticle}:
+                    </span>
+                  )}
+                  <span className="uic-BundleView-label-name">{item.name}</span>
+                  <span className="uic-BundleView-label-price">
+                    {formatPrice(item.price)}
+                  </span>
+                </label>
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+
+      {selectedItems.length > 0 && (
+        <div className="uic-BundleView-cart">
+          <div>
+            {translations.totalPrice}:{' '}
+            <span className="uic-BundleView-label-price">
+              {formatPrice(price)}
+            </span>
+          </div>
+          <button className="uic-BundleView-addToCart">
+            {translations.addToCart(selectedItems.length)}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/demo/src/BundleView.js
+++ b/examples/demo/src/BundleView.js
@@ -35,7 +35,7 @@ export function BundleView(props) {
 
   useEffect(() => {
     setPrice(getAmount(selectedItems));
-  }, [selectedItems]);
+  }, [selectedItems, getAmount]);
 
   return (
     <div className="uic-BundleView-container">


### PR DESCRIPTION
This adds a new view for Frequently Bought Together in the demo: the **Bundle view**.

## Description

This view aims at adding products to your cart directly from the product page.

## Preview


https://user-images.githubusercontent.com/6137112/119667830-ed14b200-be36-11eb-8ccd-f7b808b08ea2.mp4

## API

(Note that this is an un-official API for now, just living in the demo.)

### Basic

```js
<FrequentlyBoughtTogether
  searchClient={searchClient}
  indexName={indexName}
  objectIDs={[selectedProduct.objectID]}
  itemComponent={BundleItem}
  view={(props) => (
    <BundleView {...props} currentItem={selectedProduct} />
  )}
/>
```

### Advanced

```js
<FrequentlyBoughtTogether
  searchClient={searchClient}
  indexName={indexName}
  objectIDs={[selectedProduct.objectID]}
  itemComponent={BundleItem}
  view={(props) => (
    <BundleView
      {...props}
      currentItem={selectedProduct}
      formatPrice={(price) => `${price}€`}
      getAmountDefault={(items) =>
        items.reduce((sum, current) => sum + current.price, 0)
      }
      translations={{
        totalPrice: 'Prix total ',
        thisArticle: 'Cet article',
        addToCart: (count) => {
          if (count === 1) {
            return `Ajouter ${count} produit au panier`;
          }

          return `Ajouter ${count} produits au panier`;
        },
      }}
    />
  )}
/>;
```

## Notes

Ignore the design for now, this will be re-iterated on later.