### PR TITLE
feat(component): pass `createElement` and `Fragment` components

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  rootDir: process.cwd(),
+  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
+  testPathIgnorePatterns: ['node_modules/', 'dist/'],
+  coveragePathIgnorePatterns: ['node_modules/', 'dist/'],
+  globals: {
+    __DEV__: true,
+    __TEST__: true,
+  },
+};

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@rollup/plugin-json": "4.1.0",
     "@rollup/plugin-node-resolve": "13.0.0",
     "@rollup/plugin-replace": "2.4.2",
+    "@testing-library/jest-dom": "5.12.0",
     "@testing-library/react": "11.2.6",
     "@testing-library/react-hooks": "5.1.2",
     "@types/jest": "^26.0.23",

--- a/packages/js-horizontal-slider/README.md
+++ b/packages/js-horizontal-slider/README.md
@@ -69,7 +69,35 @@ The items to display in the component.
 
 ### `itemComponent`
 
-> `({ item }) => JSX.Element` | **required**
+<blockquote>
+<details>
+
+<summary><code>(props: ItemComponentProps) => JSX.Element</code> | <b>required</b></summary>
+
+```ts
+type ItemComponentProps<TObject> = {
+  item: TObject;
+  /**
+   * The function to create virtual nodes.
+   *
+   * @default React.createElement
+   */
+  createElement: (
+    type: any,
+    props: Record<string, any> | null,
+    ...children: JSX.Element[]
+  ) => JSX.Element;
+  /**
+   * The component to use to create fragments.
+   *
+   * @default React.Fragment
+   */
+  Fragment: any;
+};
+```
+
+</details>
+</blockquote>
 
 The item component to display.
 

--- a/packages/js-recommendations/README.md
+++ b/packages/js-recommendations/README.md
@@ -66,7 +66,35 @@ The container for the `relatedProducts` component. You can either pass a [CSS se
 
 ##### `itemComponent`
 
-> `({ item }) => JSX.Element` | **required**
+<blockquote>
+<details>
+
+<summary><code>(props: ItemComponentProps) => JSX.Element</code> | <b>required</b></summary>
+
+```ts
+type ItemComponentProps<TObject> = {
+  item: TObject;
+  /**
+   * The function to create virtual nodes.
+   *
+   * @default React.createElement
+   */
+  createElement: (
+    type: any,
+    props: Record<string, any> | null,
+    ...children: JSX.Element[]
+  ) => JSX.Element;
+  /**
+   * The component to use to create fragments.
+   *
+   * @default React.Fragment
+   */
+  Fragment: any;
+};
+```
+
+</details>
+</blockquote>
 
 The product component to display.
 
@@ -119,11 +147,16 @@ The translations for the component.
 <summary><code>(props: ChildrenProps) => JSX.Element</code></summary>
 
 ```ts
-type ChildrenProps<TObject> = {
+type ComponentProps<TObject> = RendererProps & {
   classNames: RecommendationClassNames;
   recommendations: TObject[];
   translations: Required<RecommendationTranslations>;
-  View(props: unknown): JSX.Element;
+};
+
+type ChildrenProps<TObject> = ComponentProps<TObject> & {
+  Fallback(props: RendererProps): JSX.Element | null;
+  Header(props: ComponentProps<TObject>): JSX.Element | null;
+  View(props: RendererProps & unknown): JSX.Element;
 };
 ```
 
@@ -204,7 +237,35 @@ The container for the `frequentlyBoughtTogether` component. You can either pass 
 
 ##### `itemComponent`
 
-> `({ item }) => JSX.Element` | **required**
+<blockquote>
+<details>
+
+<summary><code>(props: ItemComponentProps) => JSX.Element</code> | <b>required</b></summary>
+
+```ts
+type ItemComponentProps<TObject> = {
+  item: TObject;
+  /**
+   * The function to create virtual nodes.
+   *
+   * @default React.createElement
+   */
+  createElement: (
+    type: any,
+    props: Record<string, any> | null,
+    ...children: JSX.Element[]
+  ) => JSX.Element;
+  /**
+   * The component to use to create fragments.
+   *
+   * @default React.Fragment
+   */
+  Fragment: any;
+};
+```
+
+</details>
+</blockquote>
 
 The product component to display.
 
@@ -257,11 +318,16 @@ The translations for the component.
 <summary><code>(props: ChildrenProps) => JSX.Element</code></summary>
 
 ```ts
-type ChildrenProps<TObject> = {
+type ComponentProps<TObject> = RendererProps & {
   classNames: RecommendationClassNames;
   recommendations: TObject[];
   translations: Required<RecommendationTranslations>;
-  View(props: unknown): JSX.Element;
+};
+
+type ChildrenProps<TObject> = ComponentProps<TObject> & {
+  Fallback(props: RendererProps): JSX.Element | null;
+  Header(props: ComponentProps<TObject>): JSX.Element | null;
+  View(props: RendererProps & unknown): JSX.Element;
 };
 ```
 

--- a/packages/js-recommendations/README.md
+++ b/packages/js-recommendations/README.md
@@ -318,8 +318,10 @@ The translations for the component.
 <summary><code>(props: ChildrenProps) => JSX.Element</code></summary>
 
 ```ts
-type ComponentProps<TObject> = RendererProps & {
+type ComponentProps<TObject> = {
+  createElement: Preact.createElement;
   classNames: RecommendationClassNames;
+  Fragment: Preact.Fragment;
   recommendations: TObject[];
   translations: Required<RecommendationTranslations>;
 };

--- a/packages/react-horizontal-slider/README.md
+++ b/packages/react-horizontal-slider/README.md
@@ -60,7 +60,35 @@ The items to display in the component.
 
 ### `itemComponent`
 
-> `({ item }) => JSX.Element` | **required**
+<blockquote>
+<details>
+
+<summary><code>(props: ItemComponentProps) => JSX.Element</code> | <b>required</b></summary>
+
+```ts
+type ItemComponentProps<TObject> = {
+  item: TObject;
+  /**
+   * The function to create virtual nodes.
+   *
+   * @default React.createElement
+   */
+  createElement: (
+    type: any,
+    props: Record<string, any> | null,
+    ...children: JSX.Element[]
+  ) => JSX.Element;
+  /**
+   * The component to use to create fragments.
+   *
+   * @default React.Fragment
+   */
+  Fragment: any;
+};
+```
+
+</details>
+</blockquote>
 
 The item component to display.
 

--- a/packages/react-horizontal-slider/src/HorizontalSlider.tsx
+++ b/packages/react-horizontal-slider/src/HorizontalSlider.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, {
+  createElement,
+  Fragment,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
 
 let lastHorizontalSliderId = 0;
 
@@ -31,9 +37,32 @@ export type HorizontalSliderTranslations = Partial<{
   nextButtonTitle: string;
 }>;
 
+export type ItemComponentProps<TItem> = RendererProps & {
+  item: TItem;
+};
+
+export type RendererProps = {
+  /**
+   * The function to create virtual nodes.
+   *
+   * @default React.createElement
+   */
+  createElement: (
+    type: any,
+    props: Record<string, any> | null,
+    ...children: JSX.Element[]
+  ) => JSX.Element;
+  /**
+   * The component to use to create fragments.
+   *
+   * @default React.Fragment
+   */
+  Fragment: any;
+};
+
 export type HorizontalSliderProps<TItem extends RecordWithObjectID> = {
   items: TItem[];
-  itemComponent({ item: TItem }): JSX.Element;
+  itemComponent(props: ItemComponentProps<TItem>): JSX.Element;
   classNames?: HorizontalSliderClassnames;
   translations?: HorizontalSliderTranslations;
 };
@@ -149,7 +178,11 @@ export function HorizontalSlider<TObject extends RecordWithObjectID>(
             aria-roledescription="slide"
             aria-label={`${index + 1} of ${props.items.length}`}
           >
-            <props.itemComponent item={item} />
+            <props.itemComponent
+              createElement={createElement}
+              Fragment={Fragment}
+              item={item}
+            />
           </li>
         ))}
       </ol>

--- a/packages/react-horizontal-slider/src/HorizontalSlider.tsx
+++ b/packages/react-horizontal-slider/src/HorizontalSlider.tsx
@@ -16,6 +16,16 @@ function cx(...classNames: Array<string | undefined>) {
   return classNames.filter(Boolean).join(' ');
 }
 
+type ComponentChild =
+  | JSX.Element
+  | object
+  | string
+  | number
+  | boolean
+  | null
+  | undefined;
+type ComponentChildren = ComponentChild[] | ComponentChild;
+
 type RecordWithObjectID<TObject = {}> = TObject & {
   objectID: string;
 };
@@ -50,7 +60,7 @@ export type RendererProps = {
   createElement: (
     type: any,
     props: Record<string, any> | null,
-    ...children: JSX.Element[]
+    ...children: ComponentChildren[]
   ) => JSX.Element;
   /**
    * The component to use to create fragments.

--- a/packages/react-horizontal-slider/src/__tests__/HorizontalSlider.test.tsx
+++ b/packages/react-horizontal-slider/src/__tests__/HorizontalSlider.test.tsx
@@ -1,0 +1,50 @@
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { HorizontalSlider } from '../HorizontalSlider';
+
+const items = [
+  { objectID: '1', name: '1' },
+  { objectID: '2', name: '2' },
+];
+
+describe('HorizontalSlider', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('render with default props', async () => {
+    render(
+      <HorizontalSlider
+        items={items}
+        itemComponent={({ item }) => <div>{item.name}</div>}
+      />
+    );
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('.uic-HorizontalSlider-container')
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('pass `createElement` and `Fragment` to itemComponent', async () => {
+    render(
+      <HorizontalSlider
+        items={items}
+        itemComponent={({ item, createElement, Fragment }) => {
+          expect(createElement).toBe(React.createElement);
+          expect(Fragment).toBe(React.Fragment);
+
+          return createElement('div', {}, item.name);
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('.uic-HorizontalSlider-container')
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/react-recommendations/README.md
+++ b/packages/react-recommendations/README.md
@@ -96,7 +96,35 @@ The component accepts all the [shared props](#shared-props) and the following:
 
 #### `itemComponent`
 
-> `({ item }) => JSX.Element` | **required**
+<blockquote>
+<details>
+
+<summary><code>(props: ItemComponentProps) => JSX.Element</code> | <b>required</b></summary>
+
+```ts
+type ItemComponentProps<TObject> = {
+  item: TObject;
+  /**
+   * The function to create virtual nodes.
+   *
+   * @default React.createElement
+   */
+  createElement: (
+    type: any,
+    props: Record<string, any> | null,
+    ...children: JSX.Element[]
+  ) => JSX.Element;
+  /**
+   * The component to use to create fragments.
+   *
+   * @default React.Fragment
+   */
+  Fragment: any;
+};
+```
+
+</details>
+</blockquote>
 
 The product component to display.
 
@@ -153,7 +181,7 @@ The translations for the component.
 ```ts
 type ViewProps<TItem extends RecordWithObjectID> = {
   items: TItem[];
-  itemComponent({ item: TItem }): JSX.Element;
+  itemComponent(props: ItemComponentProps<TItem>): JSX.Element;
 };
 ```
 
@@ -171,7 +199,11 @@ function ListView(props) {
       <ol className="auc-Recommendations-list">
         {props.items.map((item) => (
           <li key={item.objectID} className="auc-Recommendations-item">
-            <props.itemComponent item={item} />
+            <props.itemComponent
+              createElement={createElement}
+              Fragment={Fragment}
+              item={item}
+            />
           </li>
         ))}
       </ol>
@@ -182,7 +214,34 @@ function ListView(props) {
 
 #### `fallbackComponent`
 
-> `() => JSX.Element`
+<blockquote>
+<details>
+
+<summary><code>(props: RendererProps) => JSX.Element</code></summary>
+
+```ts
+type RendererProps = {
+  /**
+   * The function to create virtual nodes.
+   *
+   * @default React.createElement
+   */
+  createElement: (
+    type: any,
+    props: Record<string, any> | null,
+    ...children: JSX.Element[]
+  ) => JSX.Element;
+  /**
+   * The component to use to create fragments.
+   *
+   * @default React.Fragment
+   */
+  Fragment: any;
+};
+```
+
+</details>
+</blockquote>
 
 The fallback component to render when no recommendations are returned.
 
@@ -194,11 +253,16 @@ The fallback component to render when no recommendations are returned.
 <summary><code>(props: ChildrenProps) => JSX.Element</code></summary>
 
 ```ts
-type ChildrenProps<TObject> = {
+type ComponentProps<TObject> = RendererProps & {
   classNames: RecommendationClassNames;
   recommendations: TObject[];
   translations: Required<RecommendationTranslations>;
-  View(props: unknown): JSX.Element;
+};
+
+type ChildrenProps<TObject> = ComponentProps<TObject> & {
+  Fallback(props: RendererProps): JSX.Element | null;
+  Header(props: ComponentProps<TObject>): JSX.Element | null;
+  View(props: RendererProps & unknown): JSX.Element;
 };
 ```
 
@@ -362,7 +426,35 @@ The component accepts all the [shared props](#shared-props) and the following:
 
 #### `itemComponent`
 
-> `({ item }) => JSX.Element` | **required**
+<blockquote>
+<details>
+
+<summary><code>(props: ItemComponentProps) => JSX.Element</code> | <b>required</b></summary>
+
+```ts
+type ItemComponentProps<TObject> = {
+  item: TObject;
+  /**
+   * The function to create virtual nodes.
+   *
+   * @default React.createElement
+   */
+  createElement: (
+    type: any,
+    props: Record<string, any> | null,
+    ...children: JSX.Element[]
+  ) => JSX.Element;
+  /**
+   * The component to use to create fragments.
+   *
+   * @default React.Fragment
+   */
+  Fragment: any;
+};
+```
+
+</details>
+</blockquote>
 
 The product component to display.
 
@@ -417,7 +509,7 @@ The translations for the component.
 ```ts
 type ViewProps<TItem extends RecordWithObjectID> = {
   items: TItem[];
-  itemComponent({ item: TItem }): JSX.Element;
+  itemComponent(props: ItemComponentProps<TItem>): JSX.Element;
 };
 ```
 
@@ -435,7 +527,11 @@ function ListView(props) {
       <ol className="auc-Recommendations-list">
         {props.items.map((item) => (
           <li key={item.objectID} className="auc-Recommendations-item">
-            <props.itemComponent item={item} />
+            <props.itemComponent
+              createElement={createElement}
+              Fragment={Fragment}
+              item={item}
+            />
           </li>
         ))}
       </ol>
@@ -446,7 +542,34 @@ function ListView(props) {
 
 #### `fallbackComponent`
 
-> `() => JSX.Element`
+<blockquote>
+<details>
+
+<summary><code>(props: RendererProps) => JSX.Element</code></summary>
+
+```ts
+type RendererProps = {
+  /**
+   * The function to create virtual nodes.
+   *
+   * @default React.createElement
+   */
+  createElement: (
+    type: any,
+    props: Record<string, any> | null,
+    ...children: JSX.Element[]
+  ) => JSX.Element;
+  /**
+   * The component to use to create fragments.
+   *
+   * @default React.Fragment
+   */
+  Fragment: any;
+};
+```
+
+</details>
+</blockquote>
 
 The fallback component to render when no recommendations are returned.
 
@@ -489,11 +612,16 @@ function App({ currentObjectID }) {
 <summary><code>(props: ChildrenProps) => JSX.Element</code></summary>
 
 ```ts
-type ChildrenProps<TObject> = {
+type ComponentProps<TObject> = RendererProps & {
   classNames: RecommendationClassNames;
   recommendations: TObject[];
   translations: Required<RecommendationTranslations>;
-  View(props: unknown): JSX.Element;
+};
+
+type ChildrenProps<TObject> = ComponentProps<TObject> & {
+  Fallback(props: RendererProps): JSX.Element | null;
+  Header(props: ComponentProps<TObject>): JSX.Element | null;
+  View(props: RendererProps & unknown): JSX.Element;
 };
 ```
 

--- a/packages/react-recommendations/src/DefaultChildren.tsx
+++ b/packages/react-recommendations/src/DefaultChildren.tsx
@@ -1,24 +1,32 @@
-import React, { createElement, Fragment } from 'react';
+import React from 'react';
 
 import { ChildrenProps } from './types';
 import { cx } from './utils';
 
 export function DefaultChildren<TObject>(props: ChildrenProps<TObject>) {
   if (props.recommendations.length === 0) {
-    return <props.Fallback createElement={createElement} Fragment={Fragment} />;
+    return (
+      <props.Fallback
+        createElement={props.createElement}
+        Fragment={props.Fragment}
+      />
+    );
   }
 
   return (
     <section className={cx('auc-Recommendations', props.classNames.root)}>
       <props.Header
         classNames={props.classNames}
-        createElement={createElement}
-        Fragment={Fragment}
+        createElement={props.createElement}
+        Fragment={props.Fragment}
         recommendations={props.recommendations}
         translations={props.translations}
       />
 
-      <props.View createElement={createElement} Fragment={Fragment} />
+      <props.View
+        createElement={props.createElement}
+        Fragment={props.Fragment}
+      />
     </section>
   );
 }

--- a/packages/react-recommendations/src/DefaultChildren.tsx
+++ b/packages/react-recommendations/src/DefaultChildren.tsx
@@ -1,22 +1,24 @@
-import React from 'react';
+import React, { createElement, Fragment } from 'react';
 
 import { ChildrenProps } from './types';
 import { cx } from './utils';
 
 export function DefaultChildren<TObject>(props: ChildrenProps<TObject>) {
   if (props.recommendations.length === 0) {
-    return <props.Fallback />;
+    return <props.Fallback createElement={createElement} Fragment={Fragment} />;
   }
 
   return (
     <section className={cx('auc-Recommendations', props.classNames.root)}>
       <props.Header
         classNames={props.classNames}
+        createElement={createElement}
+        Fragment={Fragment}
         recommendations={props.recommendations}
         translations={props.translations}
       />
 
-      <props.View />
+      <props.View createElement={createElement} Fragment={Fragment} />
     </section>
   );
 }

--- a/packages/react-recommendations/src/FrequentlyBoughtTogether.tsx
+++ b/packages/react-recommendations/src/FrequentlyBoughtTogether.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { createElement, Fragment, useMemo } from 'react';
 
 import { DefaultChildren } from './DefaultChildren';
 import { DefaultFallback } from './DefaultFallback';
@@ -40,6 +40,8 @@ export function FrequentlyBoughtTogether<TObject>(
   const View = (viewProps: unknown) => (
     <ViewComponent
       classNames={classNames}
+      createElement={createElement}
+      Fragment={Fragment}
       itemComponent={props.itemComponent}
       items={recommendations}
       translations={translations}
@@ -49,7 +51,9 @@ export function FrequentlyBoughtTogether<TObject>(
 
   return children({
     classNames,
+    createElement,
     Fallback,
+    Fragment,
     Header,
     recommendations,
     translations,

--- a/packages/react-recommendations/src/FrequentlyBoughtTogether.tsx
+++ b/packages/react-recommendations/src/FrequentlyBoughtTogether.tsx
@@ -34,9 +34,22 @@ export function FrequentlyBoughtTogether<TObject>(
   const classNames = props.classNames ?? {};
 
   const children = props.children ?? DefaultChildren;
-  const Fallback = props.fallbackComponent ?? DefaultFallback;
-  const Header = props.headerComponent ?? DefaultHeader;
+  const FallbackComponent = props.fallbackComponent ?? DefaultFallback;
+  const HeaderComponent = props.headerComponent ?? DefaultHeader;
   const ViewComponent = props.view ?? ListView;
+
+  const Fallback = () => (
+    <FallbackComponent createElement={createElement} Fragment={Fragment} />
+  );
+  const Header = () => (
+    <HeaderComponent
+      classNames={classNames}
+      createElement={createElement}
+      Fragment={Fragment}
+      recommendations={recommendations}
+      translations={translations}
+    />
+  );
   const View = (viewProps: unknown) => (
     <ViewComponent
       classNames={classNames}

--- a/packages/react-recommendations/src/ListView.tsx
+++ b/packages/react-recommendations/src/ListView.tsx
@@ -1,4 +1,4 @@
-import React, { createElement, Fragment } from 'react';
+import React from 'react';
 
 import {
   RecommendationClassNames,
@@ -25,8 +25,8 @@ export function ListView<TItem extends RecordWithObjectID>(
             className={cx('auc-Recommendations-item', props.classNames.item)}
           >
             <props.itemComponent
-              createElement={createElement}
-              Fragment={Fragment}
+              createElement={props.createElement}
+              Fragment={props.Fragment}
               item={item}
             />
           </li>

--- a/packages/react-recommendations/src/ListView.tsx
+++ b/packages/react-recommendations/src/ListView.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createElement, Fragment } from 'react';
 
 import {
   RecommendationClassNames,
@@ -24,7 +24,11 @@ export function ListView<TItem extends RecordWithObjectID>(
             key={item.objectID}
             className={cx('auc-Recommendations-item', props.classNames.item)}
           >
-            <props.itemComponent item={item} />
+            <props.itemComponent
+              createElement={createElement}
+              Fragment={Fragment}
+              item={item}
+            />
           </li>
         ))}
       </ol>

--- a/packages/react-recommendations/src/RelatedProducts.tsx
+++ b/packages/react-recommendations/src/RelatedProducts.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { createElement, Fragment, useMemo } from 'react';
 
 import { DefaultChildren } from './DefaultChildren';
 import { DefaultFallback } from './DefaultFallback';
@@ -36,6 +36,8 @@ export function RelatedProducts<TObject>(props: RelatedProductsProps<TObject>) {
   const View = (viewProps: unknown) => (
     <ViewComponent
       classNames={classNames}
+      createElement={createElement}
+      Fragment={Fragment}
       itemComponent={props.itemComponent}
       items={recommendations}
       translations={translations}
@@ -45,7 +47,9 @@ export function RelatedProducts<TObject>(props: RelatedProductsProps<TObject>) {
 
   return children({
     classNames,
+    createElement,
     Fallback,
+    Fragment,
     Header,
     recommendations,
     translations,

--- a/packages/react-recommendations/src/RelatedProducts.tsx
+++ b/packages/react-recommendations/src/RelatedProducts.tsx
@@ -30,9 +30,22 @@ export function RelatedProducts<TObject>(props: RelatedProductsProps<TObject>) {
   const classNames = props.classNames ?? {};
 
   const children = props.children ?? DefaultChildren;
-  const Fallback = props.fallbackComponent ?? DefaultFallback;
-  const Header = props.headerComponent ?? DefaultHeader;
+  const FallbackComponent = props.fallbackComponent ?? DefaultFallback;
+  const HeaderComponent = props.headerComponent ?? DefaultHeader;
   const ViewComponent = props.view ?? ListView;
+
+  const Fallback = () => (
+    <FallbackComponent createElement={createElement} Fragment={Fragment} />
+  );
+  const Header = () => (
+    <HeaderComponent
+      classNames={classNames}
+      createElement={createElement}
+      Fragment={Fragment}
+      recommendations={recommendations}
+      translations={translations}
+    />
+  );
   const View = (viewProps: unknown) => (
     <ViewComponent
       classNames={classNames}

--- a/packages/react-recommendations/src/__tests__/FrequentlyBoughtTogether.test.tsx
+++ b/packages/react-recommendations/src/__tests__/FrequentlyBoughtTogether.test.tsx
@@ -1,0 +1,136 @@
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { createRecommendationsClient } from '../../../../test/utils';
+import { FrequentlyBoughtTogether } from '../FrequentlyBoughtTogether';
+
+const { searchClient } = createRecommendationsClient();
+
+const ItemComponent = ({ item }) => <div>{item.name}</div>;
+
+describe('FrequentlyBoughtTogether', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('render with default props', async () => {
+    render(
+      <FrequentlyBoughtTogether
+        // @ts-expect-error
+        searchClient={searchClient}
+        indexName={'indexName'}
+        objectIDs={['objectID']}
+        itemComponent={ItemComponent}
+      />
+    );
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('.auc-Recommendations')
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('view', () => {
+    test('pass `createElement` and `Fragment` to the component', async () => {
+      render(
+        <FrequentlyBoughtTogether
+          // @ts-expect-error
+          searchClient={searchClient}
+          indexName={'indexName'}
+          objectIDs={['objectID']}
+          itemComponent={ItemComponent}
+          view={({ createElement, Fragment }) => {
+            expect(createElement).toBe(React.createElement);
+            expect(Fragment).toBe(React.Fragment);
+
+            return createElement('div', {}, 'view');
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(
+          document.querySelector('.auc-Recommendations')
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('itemComponent', () => {
+    test('pass `createElement` and `Fragment` to the component', async () => {
+      render(
+        <FrequentlyBoughtTogether
+          // @ts-expect-error
+          searchClient={searchClient}
+          indexName={'indexName'}
+          objectIDs={['objectID']}
+          itemComponent={({ createElement, Fragment }) => {
+            expect(createElement).toBe(React.createElement);
+            expect(Fragment).toBe(React.Fragment);
+
+            return createElement('div', {}, 'itemComponent');
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(
+          document.querySelector('.auc-Recommendations')
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('headerComponent', () => {
+    test('pass `createElement` and `Fragment` to the component', async () => {
+      render(
+        <FrequentlyBoughtTogether
+          // @ts-expect-error
+          searchClient={searchClient}
+          indexName={'indexName'}
+          objectIDs={['objectID']}
+          itemComponent={ItemComponent}
+          headerComponent={({ createElement, Fragment }) => {
+            expect(createElement).toBe(React.createElement);
+            expect(Fragment).toBe(React.Fragment);
+
+            return createElement('div', {}, 'header');
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(
+          document.querySelector('.auc-Recommendations')
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('fallbackComponent', () => {
+    test('pass `createElement` and `Fragment` to the component', async () => {
+      render(
+        <FrequentlyBoughtTogether
+          // @ts-expect-error
+          searchClient={searchClient}
+          indexName={'indexName'}
+          objectIDs={['objectID']}
+          itemComponent={ItemComponent}
+          fallbackComponent={({ createElement, Fragment }) => {
+            expect(createElement).toBe(React.createElement);
+            expect(Fragment).toBe(React.Fragment);
+
+            return createElement('div', {}, 'fallbackComponent');
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(
+          document.querySelector('.auc-Recommendations')
+        ).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/packages/react-recommendations/src/__tests__/FrequentlyBoughtTogether.test.tsx
+++ b/packages/react-recommendations/src/__tests__/FrequentlyBoughtTogether.test.tsx
@@ -6,7 +6,7 @@ import { FrequentlyBoughtTogether } from '../FrequentlyBoughtTogether';
 
 const { searchClient } = createRecommendationsClient();
 
-const ItemComponent = ({ item }) => <div>{item.name}</div>;
+const Item = ({ item }) => <div>{item.name}</div>;
 
 describe('FrequentlyBoughtTogether', () => {
   beforeEach(() => {
@@ -18,9 +18,9 @@ describe('FrequentlyBoughtTogether', () => {
       <FrequentlyBoughtTogether
         // @ts-expect-error
         searchClient={searchClient}
-        indexName={'indexName'}
+        indexName="indexName"
         objectIDs={['objectID']}
-        itemComponent={ItemComponent}
+        itemComponent={Item}
       />
     );
 
@@ -37,9 +37,9 @@ describe('FrequentlyBoughtTogether', () => {
         <FrequentlyBoughtTogether
           // @ts-expect-error
           searchClient={searchClient}
-          indexName={'indexName'}
+          indexName="indexName"
           objectIDs={['objectID']}
-          itemComponent={ItemComponent}
+          itemComponent={Item}
           view={({ createElement, Fragment }) => {
             expect(createElement).toBe(React.createElement);
             expect(Fragment).toBe(React.Fragment);
@@ -63,7 +63,7 @@ describe('FrequentlyBoughtTogether', () => {
         <FrequentlyBoughtTogether
           // @ts-expect-error
           searchClient={searchClient}
-          indexName={'indexName'}
+          indexName="indexName"
           objectIDs={['objectID']}
           itemComponent={({ createElement, Fragment }) => {
             expect(createElement).toBe(React.createElement);
@@ -88,9 +88,9 @@ describe('FrequentlyBoughtTogether', () => {
         <FrequentlyBoughtTogether
           // @ts-expect-error
           searchClient={searchClient}
-          indexName={'indexName'}
+          indexName="indexName"
           objectIDs={['objectID']}
-          itemComponent={ItemComponent}
+          itemComponent={Item}
           headerComponent={({ createElement, Fragment }) => {
             expect(createElement).toBe(React.createElement);
             expect(Fragment).toBe(React.Fragment);
@@ -114,9 +114,9 @@ describe('FrequentlyBoughtTogether', () => {
         <FrequentlyBoughtTogether
           // @ts-expect-error
           searchClient={searchClient}
-          indexName={'indexName'}
+          indexName="indexName"
           objectIDs={['objectID']}
-          itemComponent={ItemComponent}
+          itemComponent={Item}
           fallbackComponent={({ createElement, Fragment }) => {
             expect(createElement).toBe(React.createElement);
             expect(Fragment).toBe(React.Fragment);

--- a/packages/react-recommendations/src/__tests__/RelatedProducts.test.tsx
+++ b/packages/react-recommendations/src/__tests__/RelatedProducts.test.tsx
@@ -6,7 +6,7 @@ import { RelatedProducts } from '../RelatedProducts';
 
 const { searchClient } = createRecommendationsClient();
 
-const ItemComponent = ({ item }) => <div>{item.name}</div>;
+const Item = ({ item }) => <div>{item.name}</div>;
 
 describe('RelatedProducts', () => {
   beforeEach(() => {
@@ -18,9 +18,9 @@ describe('RelatedProducts', () => {
       <RelatedProducts
         // @ts-expect-error
         searchClient={searchClient}
-        indexName={'indexName'}
+        indexName="indexName"
         objectIDs={['objectID']}
-        itemComponent={ItemComponent}
+        itemComponent={Item}
       />
     );
 
@@ -37,9 +37,9 @@ describe('RelatedProducts', () => {
         <RelatedProducts
           // @ts-expect-error
           searchClient={searchClient}
-          indexName={'indexName'}
+          indexName="indexName"
           objectIDs={['objectID']}
-          itemComponent={ItemComponent}
+          itemComponent={Item}
           view={({ createElement, Fragment }: any) => {
             expect(createElement).toBe(React.createElement);
             expect(Fragment).toBe(React.Fragment);
@@ -63,7 +63,7 @@ describe('RelatedProducts', () => {
         <RelatedProducts
           // @ts-expect-error
           searchClient={searchClient}
-          indexName={'indexName'}
+          indexName="indexName"
           objectIDs={['objectID']}
           itemComponent={({ item, createElement, Fragment }: any) => {
             expect(createElement).toBe(React.createElement);
@@ -88,9 +88,9 @@ describe('RelatedProducts', () => {
         <RelatedProducts
           // @ts-expect-error
           searchClient={searchClient}
-          indexName={'indexName'}
+          indexName="indexName"
           objectIDs={['objectID']}
-          itemComponent={ItemComponent}
+          itemComponent={Item}
           headerComponent={({ createElement, Fragment }: any) => {
             expect(createElement).toBe(React.createElement);
             expect(Fragment).toBe(React.Fragment);
@@ -114,9 +114,9 @@ describe('RelatedProducts', () => {
         <RelatedProducts
           // @ts-expect-error
           searchClient={searchClient}
-          indexName={'indexName'}
+          indexName="indexName"
           objectIDs={['objectID']}
-          itemComponent={ItemComponent}
+          itemComponent={Item}
           fallbackComponent={({ createElement, Fragment }: any) => {
             expect(createElement).toBe(React.createElement);
             expect(Fragment).toBe(React.Fragment);

--- a/packages/react-recommendations/src/__tests__/RelatedProducts.tsx
+++ b/packages/react-recommendations/src/__tests__/RelatedProducts.tsx
@@ -1,0 +1,136 @@
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { createRecommendationsClient } from '../../../../test/utils';
+import { RelatedProducts } from '../RelatedProducts';
+
+const { searchClient } = createRecommendationsClient();
+
+const ItemComponent = ({ item }) => <div>{item.name}</div>;
+
+describe('RelatedProducts', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('render with default props', async () => {
+    render(
+      <RelatedProducts
+        // @ts-expect-error
+        searchClient={searchClient}
+        indexName={'indexName'}
+        objectIDs={['objectID']}
+        itemComponent={ItemComponent}
+      />
+    );
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('.auc-Recommendations')
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('view', () => {
+    test('pass `createElement` and `Fragment` to the component', async () => {
+      render(
+        <RelatedProducts
+          // @ts-expect-error
+          searchClient={searchClient}
+          indexName={'indexName'}
+          objectIDs={['objectID']}
+          itemComponent={ItemComponent}
+          view={({ createElement, Fragment }: any) => {
+            expect(createElement).toBe(React.createElement);
+            expect(Fragment).toBe(React.Fragment);
+
+            return createElement('div', {}, 'view');
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(
+          document.querySelector('.auc-Recommendations')
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('itemComponent', () => {
+    test('pass `createElement` and `Fragment` to the component', async () => {
+      render(
+        <RelatedProducts
+          // @ts-expect-error
+          searchClient={searchClient}
+          indexName={'indexName'}
+          objectIDs={['objectID']}
+          itemComponent={({ item, createElement, Fragment }: any) => {
+            expect(createElement).toBe(React.createElement);
+            expect(Fragment).toBe(React.Fragment);
+
+            return createElement('div', {}, item.name);
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(
+          document.querySelector('.auc-Recommendations')
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('headerComponent', () => {
+    test('pass `createElement` and `Fragment` to the component', async () => {
+      render(
+        <RelatedProducts
+          // @ts-expect-error
+          searchClient={searchClient}
+          indexName={'indexName'}
+          objectIDs={['objectID']}
+          itemComponent={ItemComponent}
+          headerComponent={({ createElement, Fragment }: any) => {
+            expect(createElement).toBe(React.createElement);
+            expect(Fragment).toBe(React.Fragment);
+
+            return createElement('div', {}, 'header');
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(
+          document.querySelector('.auc-Recommendations')
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('fallbackComponent', () => {
+    test('pass `createElement` and `Fragment` to the component', async () => {
+      render(
+        <RelatedProducts
+          // @ts-expect-error
+          searchClient={searchClient}
+          indexName={'indexName'}
+          objectIDs={['objectID']}
+          itemComponent={ItemComponent}
+          fallbackComponent={({ createElement, Fragment }: any) => {
+            expect(createElement).toBe(React.createElement);
+            expect(Fragment).toBe(React.Fragment);
+
+            return createElement('div', {}, 'fallbackComponent');
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(
+          document.querySelector('.auc-Recommendations')
+        ).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/packages/react-recommendations/src/__tests__/useRecommendations.test.ts
+++ b/packages/react-recommendations/src/__tests__/useRecommendations.test.ts
@@ -1,61 +1,8 @@
 import { renderHook } from '@testing-library/react-hooks';
 
-import {
-  createMultiSearchResponse,
-  createSearchClient,
-} from '../../../../test/utils';
+import { createRecommendationsClient } from '../../../../test/utils';
 import { RecommendationModel } from '../types';
 import { useRecommendations } from '../useRecommendations';
-
-const hit = {
-  name: 'Landoh 4-Pocket Jumpsuit',
-  category: 'Women - Jumpsuits-Overalls',
-  price: 250,
-  url: 'women/jumpsuits-overalls/d06270-9132-995',
-  hierarchical_categories: {
-    lvl0: 'women',
-    lvl1: 'women > jeans & bottoms',
-    lvl2: 'women > jeans & bottoms > jumpsuits & overalls',
-  },
-  keywords: [
-    'women',
-    'jeans & bottoms',
-    'jumpsuits & overalls',
-    'Jumpsuits',
-    'Loose',
-    'Woven',
-    'Long sleeve',
-    'Grey',
-  ],
-  objectID: 'D06270-9132-995',
-  recommendations: [
-    { objectID: '1', score: 1.99 },
-    { objectID: '2', score: 2.99 },
-    { objectID: '3', score: 3.99 },
-  ],
-};
-
-function createRecommendationsClient() {
-  const index = {
-    getObjects: jest.fn(() => Promise.resolve({ results: [hit] })),
-  };
-  const searchClient = createSearchClient({
-    // @ts-expect-error `initIndex` is not part of the lite bundle
-    initIndex: jest.fn(() => index),
-    search: jest.fn(() =>
-      Promise.resolve(
-        createMultiSearchResponse({
-          hits: [hit],
-        })
-      )
-    ),
-  });
-
-  return {
-    index,
-    searchClient,
-  };
-}
 
 describe('useRecommendations', () => {
   test('calls the correct index for "related-products"', async () => {

--- a/packages/react-recommendations/src/types/RecommendationsComponentProps.ts
+++ b/packages/react-recommendations/src/types/RecommendationsComponentProps.ts
@@ -3,6 +3,16 @@ import { RecommendationTranslations } from './RecommendationTranslations';
 import { RecordWithObjectID } from './RecordWithObjectID';
 import { ViewProps } from './ViewProps';
 
+type ComponentChild =
+  | JSX.Element
+  | object
+  | string
+  | number
+  | boolean
+  | null
+  | undefined;
+type ComponentChildren = ComponentChild[] | ComponentChild;
+
 export type ComponentProps<TObject> = RendererProps & {
   classNames: RecommendationClassNames;
   recommendations: TObject[];
@@ -28,7 +38,7 @@ export type RendererProps = {
   createElement: (
     type: any,
     props: Record<string, any> | null,
-    ...children: JSX.Element[]
+    ...children: ComponentChildren[]
   ) => JSX.Element;
   /**
    * The component to use to create fragments.

--- a/packages/react-recommendations/src/types/RecommendationsComponentProps.ts
+++ b/packages/react-recommendations/src/types/RecommendationsComponentProps.ts
@@ -3,23 +3,46 @@ import { RecommendationTranslations } from './RecommendationTranslations';
 import { RecordWithObjectID } from './RecordWithObjectID';
 import { ViewProps } from './ViewProps';
 
-export type ComponentProps<TObject> = {
+export type ComponentProps<TObject> = RendererProps & {
   classNames: RecommendationClassNames;
   recommendations: TObject[];
   translations: Required<RecommendationTranslations>;
 };
 
 export type ChildrenProps<TObject> = ComponentProps<TObject> & {
-  Fallback(): JSX.Element | null;
+  Fallback(props: RendererProps): JSX.Element | null;
   Header(props: ComponentProps<TObject>): JSX.Element | null;
-  View(props: unknown): JSX.Element;
+  View(props: RendererProps & unknown): JSX.Element;
+};
+
+export type ItemComponentProps<TObject> = RendererProps & {
+  item: TObject;
+};
+
+export type RendererProps = {
+  /**
+   * The function to create virtual nodes.
+   *
+   * @default React.createElement
+   */
+  createElement: (
+    type: any,
+    props: Record<string, any> | null,
+    ...children: JSX.Element[]
+  ) => JSX.Element;
+  /**
+   * The component to use to create fragments.
+   *
+   * @default React.Fragment
+   */
+  Fragment: any;
 };
 
 export type RecommendationsComponentProps<TObject> = {
-  itemComponent({ item: TObject }): JSX.Element;
+  itemComponent(props: ItemComponentProps<TObject>): JSX.Element;
   classNames?: RecommendationClassNames;
   children?(props: ChildrenProps<TObject>): JSX.Element;
-  fallbackComponent?(): JSX.Element;
+  fallbackComponent?(props: RendererProps): JSX.Element;
   headerComponent?(props: ComponentProps<TObject>): JSX.Element;
   translations?: Required<RecommendationTranslations>;
   view?(

--- a/packages/react-recommendations/src/types/RecommendationsComponentProps.ts
+++ b/packages/react-recommendations/src/types/RecommendationsComponentProps.ts
@@ -31,7 +31,7 @@ export type ItemComponentProps<TObject> = RendererProps & {
 
 export type RendererProps = {
   /**
-   * The function to create virtual nodes.
+   * The function to create JSX Elements.
    *
    * @default React.createElement
    */

--- a/packages/react-recommendations/src/types/ViewProps.ts
+++ b/packages/react-recommendations/src/types/ViewProps.ts
@@ -1,12 +1,18 @@
+import {
+  ItemComponentProps,
+  RendererProps,
+} from './RecommendationsComponentProps';
 import { RecordWithObjectID } from './RecordWithObjectID';
 
 export type ViewProps<
   TItem extends RecordWithObjectID,
   TTranslations extends Record<string, string>,
   TClassNames extends Record<string, string>
-> = {
+> = RendererProps & {
   classNames: TClassNames;
-  itemComponent({ item: TItem }): JSX.Element;
+  itemComponent(
+    props: ItemComponentProps<RecordWithObjectID<TItem>>
+  ): JSX.Element;
   items: TItem[];
   translations: TTranslations;
 };

--- a/test/utils/createRecommendationsClient.ts
+++ b/test/utils/createRecommendationsClient.ts
@@ -1,0 +1,51 @@
+import { createMultiSearchResponse, createSearchClient } from '.';
+
+const hit = {
+  name: 'Landoh 4-Pocket Jumpsuit',
+  category: 'Women - Jumpsuits-Overalls',
+  price: 250,
+  url: 'women/jumpsuits-overalls/d06270-9132-995',
+  hierarchical_categories: {
+    lvl0: 'women',
+    lvl1: 'women > jeans & bottoms',
+    lvl2: 'women > jeans & bottoms > jumpsuits & overalls',
+  },
+  keywords: [
+    'women',
+    'jeans & bottoms',
+    'jumpsuits & overalls',
+    'Jumpsuits',
+    'Loose',
+    'Woven',
+    'Long sleeve',
+    'Grey',
+  ],
+  objectID: 'D06270-9132-995',
+  recommendations: [
+    { objectID: '1', score: 1.99 },
+    { objectID: '2', score: 2.99 },
+    { objectID: '3', score: 3.99 },
+  ],
+};
+
+export function createRecommendationsClient() {
+  const index = {
+    getObjects: jest.fn(() => Promise.resolve({ results: [hit] })),
+  };
+  const searchClient = createSearchClient({
+    // @ts-expect-error `initIndex` is not part of the lite bundle
+    initIndex: jest.fn(() => index),
+    search: jest.fn(() =>
+      Promise.resolve(
+        createMultiSearchResponse({
+          hits: [hit],
+        })
+      )
+    ),
+  });
+
+  return {
+    index,
+    searchClient,
+  };
+}

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './createApiResponse';
+export * from './createRecommendationsClient';
 export * from './createSearchClient';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1243,7 +1243,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.8", "@babel/runtime@^7.6.3", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.8", "@babel/runtime@^7.6.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.14.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
   integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
@@ -3087,6 +3087,20 @@
     lz-string "^1.4.4"
     pretty-format "^26.6.2"
 
+"@testing-library/jest-dom@5.12.0":
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.12.0.tgz#6a5d340b092c44b7bce17a4791b47d9bc2c61443"
+  integrity sha512-N9Y82b2Z3j6wzIoAqajlKVF1Zt7sOH0pPee0sUHXHc5cv2Fdn23r+vpWm0MBBoGJtPOly5+Bdx1lnc3CD+A+ow==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__jest-dom" "^5.9.1"
+    aria-query "^4.2.2"
+    chalk "^3.0.0"
+    css "^3.0.0"
+    css.escape "^1.5.1"
+    lodash "^4.17.15"
+    redent "^3.0.0"
+
 "@testing-library/react-hooks@5.1.2":
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-5.1.2.tgz#36e359d992bb652a9885c6fa9aa394639cbe8dd3"
@@ -3206,7 +3220,7 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^26.0.23":
+"@types/jest@*", "@types/jest@^26.0.23":
   version "26.0.23"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.23.tgz#a1b7eab3c503b80451d019efb588ec63522ee4e7"
   integrity sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==
@@ -3303,6 +3317,13 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
+
+"@types/testing-library__jest-dom@^5.9.1":
+  version "5.9.5"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz#5bf25c91ad2d7b38f264b12275e5c92a66d849b0"
+  integrity sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==
+  dependencies:
+    "@types/jest" "*"
 
 "@types/yargs-parser@*":
   version "20.2.0"
@@ -5158,6 +5179,20 @@ css-what@^3.2.1:
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.4.2.tgz#ea7026fcb01777edbde52124e21f327e7ae950e4"
   integrity sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==
+
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
+css@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css/-/css-3.0.0.tgz#4447a4d58fdd03367c516ca9f64ae365cee4aa5d"
+  integrity sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==
+  dependencies:
+    inherits "^2.0.4"
+    source-map "^0.6.1"
+    source-map-resolve "^0.6.0"
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -11683,6 +11718,14 @@ source-map-resolve@^0.5.0:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
+
+source-map-resolve@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.6.0.tgz#3d9df87e236b53f16d01e58150fc7711138e5ed2"
+  integrity sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
+  dependencies:
+    atob "^2.1.2"
+    decode-uri-component "^0.2.0"
 
 source-map-support@^0.5.6, source-map-support@~0.5.19:
   version "0.5.19"


### PR DESCRIPTION
**Summary**

Pass `createElement` and `Fragment` to the components returning a `JSX.Element` which ease the user-land code when using vanilla JavaScript. 

**JavaScript Example**

```js
relatedProducts({
  container: '#relatedProducts',
  searchClient,
  indexName,
  objectIDs: [selectedProduct.objectID],
  itemComponent({ item, createElement, Fragment }) {
    return createElement(Fragment, {}, createElement('span', {}, item.name));
  },
});
```