### PR TITLE
fix(react): use FBT hook in `FrequentlyBoughtTogether` component

### DIFF
--- a/packages/recommend-react/src/FrequentlyBoughtTogether.tsx
+++ b/packages/recommend-react/src/FrequentlyBoughtTogether.tsx
@@ -4,7 +4,7 @@ import {
 } from '@algolia/recommend-vdom';
 import React, { createElement, Fragment } from 'react';
 
-import { useRelatedProducts } from './useRelatedProducts';
+import { useFrequentlyBoughtTogether } from './useFrequentlyBoughtTogether';
 
 const UncontrolledFrequentlyBoughtTogether = createFrequentlyBoughtTogetherComponent(
   {
@@ -16,7 +16,7 @@ const UncontrolledFrequentlyBoughtTogether = createFrequentlyBoughtTogetherCompo
 export function FrequentlyBoughtTogether<TObject>(
   props: FrequentlyBoughtTogetherProps<TObject>
 ) {
-  const { recommendations } = useRelatedProducts<TObject>(props);
+  const { recommendations } = useFrequentlyBoughtTogether<TObject>(props);
 
   return (
     <UncontrolledFrequentlyBoughtTogether {...props} items={recommendations} />


### PR DESCRIPTION
React component for "Frequently Bought Together" recommendations was importing the `useRelatedProducts` hook so having both components on the same page resulted in duplicate results being displayed