### PR TITLE
fix(recommend): ignore `items` type in components

### DIFF
--- a/packages/recommend-js/src/frequentlyBoughtTogether.tsx
+++ b/packages/recommend-js/src/frequentlyBoughtTogether.tsx
@@ -6,7 +6,7 @@ import {
 } from '@algolia/recommend-core';
 import {
   createFrequentlyBoughtTogetherComponent,
-  FrequentlyBoughtTogetherProps as FrequentlyBoughtTogetherVDomProps,
+  FrequentlyBoughtTogetherProps as FrequentlyBoughtTogetherVDOMProps,
 } from '@algolia/recommend-vdom';
 import { createElement, Fragment, h, render } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
@@ -43,7 +43,7 @@ function useFrequentlyBoughtTogether<TObject>(
 type FrequentlyBoughtTogetherProps<
   TObject
 > = GetFrequentlyBoughtTogetherProps<TObject> &
-  Omit<FrequentlyBoughtTogetherVDomProps<TObject>, 'items'>;
+  Omit<FrequentlyBoughtTogetherVDOMProps<TObject>, 'items'>;
 
 function FrequentlyBoughtTogether<TObject>(
   props: FrequentlyBoughtTogetherProps<TObject>

--- a/packages/recommend-js/src/frequentlyBoughtTogether.tsx
+++ b/packages/recommend-js/src/frequentlyBoughtTogether.tsx
@@ -6,7 +6,7 @@ import {
 } from '@algolia/recommend-core';
 import {
   createFrequentlyBoughtTogetherComponent,
-  FrequentlyBoughtTogetherProps,
+  FrequentlyBoughtTogetherProps as FrequentlyBoughtTogetherVDomProps,
 } from '@algolia/recommend-vdom';
 import { createElement, Fragment, h, render } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
@@ -39,6 +39,11 @@ function useFrequentlyBoughtTogether<TObject>(
 
   return result;
 }
+
+type FrequentlyBoughtTogetherProps<
+  TObject
+> = GetFrequentlyBoughtTogetherProps<TObject> &
+  Omit<FrequentlyBoughtTogetherVDomProps<TObject>, 'items'>;
 
 function FrequentlyBoughtTogether<TObject>(
   props: FrequentlyBoughtTogetherProps<TObject>

--- a/packages/recommend-js/src/relatedProducts.tsx
+++ b/packages/recommend-js/src/relatedProducts.tsx
@@ -6,7 +6,7 @@ import {
 } from '@algolia/recommend-core';
 import {
   createRelatedProductsComponent,
-  RelatedProductsProps as RelatedProductsVDomProps,
+  RelatedProductsProps as RelatedProductsVDOMProps,
 } from '@algolia/recommend-vdom';
 import { createElement, Fragment, h, render } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
@@ -37,7 +37,7 @@ function useRelatedProducts<TObject>(props: GetRelatedProductsProps<TObject>) {
 }
 
 type RelatedProductsProps<TObject> = GetRelatedProductsProps<TObject> &
-  Omit<RelatedProductsVDomProps<TObject>, 'items'>;
+  Omit<RelatedProductsVDOMProps<TObject>, 'items'>;
 
 function RelatedProducts<TObject>(props: RelatedProductsProps<TObject>) {
   const { recommendations } = useRelatedProducts<TObject>(props);

--- a/packages/recommend-js/src/relatedProducts.tsx
+++ b/packages/recommend-js/src/relatedProducts.tsx
@@ -6,7 +6,7 @@ import {
 } from '@algolia/recommend-core';
 import {
   createRelatedProductsComponent,
-  RelatedProductsProps,
+  RelatedProductsProps as RelatedProductsVDomProps,
 } from '@algolia/recommend-vdom';
 import { createElement, Fragment, h, render } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
@@ -35,6 +35,9 @@ function useRelatedProducts<TObject>(props: GetRelatedProductsProps<TObject>) {
 
   return result;
 }
+
+type RelatedProductsProps<TObject> = GetRelatedProductsProps<TObject> &
+  Omit<RelatedProductsVDomProps<TObject>, 'items'>;
 
 function RelatedProducts<TObject>(props: RelatedProductsProps<TObject>) {
   const { recommendations } = useRelatedProducts<TObject>(props);

--- a/packages/recommend-react/src/FrequentlyBoughtTogether.tsx
+++ b/packages/recommend-react/src/FrequentlyBoughtTogether.tsx
@@ -1,6 +1,7 @@
+import { GetFrequentlyBoughtTogetherProps } from '@algolia/recommend-core';
 import {
   createFrequentlyBoughtTogetherComponent,
-  FrequentlyBoughtTogetherProps,
+  FrequentlyBoughtTogetherProps as FrequentlyBoughtTogetherVDomProps,
 } from '@algolia/recommend-vdom';
 import React, { createElement, Fragment } from 'react';
 
@@ -12,6 +13,11 @@ const UncontrolledFrequentlyBoughtTogether = createFrequentlyBoughtTogetherCompo
     Fragment,
   }
 );
+
+type FrequentlyBoughtTogetherProps<
+  TObject
+> = GetFrequentlyBoughtTogetherProps<TObject> &
+  Omit<FrequentlyBoughtTogetherVDomProps<TObject>, 'items'>;
 
 export function FrequentlyBoughtTogether<TObject>(
   props: FrequentlyBoughtTogetherProps<TObject>

--- a/packages/recommend-react/src/FrequentlyBoughtTogether.tsx
+++ b/packages/recommend-react/src/FrequentlyBoughtTogether.tsx
@@ -1,7 +1,7 @@
 import { GetFrequentlyBoughtTogetherProps } from '@algolia/recommend-core';
 import {
   createFrequentlyBoughtTogetherComponent,
-  FrequentlyBoughtTogetherProps as FrequentlyBoughtTogetherVDomProps,
+  FrequentlyBoughtTogetherProps as FrequentlyBoughtTogetherVDOMProps,
 } from '@algolia/recommend-vdom';
 import React, { createElement, Fragment } from 'react';
 
@@ -17,7 +17,7 @@ const UncontrolledFrequentlyBoughtTogether = createFrequentlyBoughtTogetherCompo
 type FrequentlyBoughtTogetherProps<
   TObject
 > = GetFrequentlyBoughtTogetherProps<TObject> &
-  Omit<FrequentlyBoughtTogetherVDomProps<TObject>, 'items'>;
+  Omit<FrequentlyBoughtTogetherVDOMProps<TObject>, 'items'>;
 
 export function FrequentlyBoughtTogether<TObject>(
   props: FrequentlyBoughtTogetherProps<TObject>

--- a/packages/recommend-react/src/RelatedProducts.tsx
+++ b/packages/recommend-react/src/RelatedProducts.tsx
@@ -1,6 +1,7 @@
+import { GetRelatedProductsProps } from '@algolia/recommend-core';
 import {
   createRelatedProductsComponent,
-  RelatedProductsProps,
+  RelatedProductsProps as RelatedProductsVDomProps,
 } from '@algolia/recommend-vdom';
 import React, { createElement, Fragment } from 'react';
 
@@ -10,6 +11,9 @@ const UncontrolledRelatedProducts = createRelatedProductsComponent({
   createElement,
   Fragment,
 });
+
+type RelatedProductsProps<TObject> = GetRelatedProductsProps<TObject> &
+  Omit<RelatedProductsVDomProps<TObject>, 'items'>;
 
 export function RelatedProducts<TObject>(props: RelatedProductsProps<TObject>) {
   const { recommendations } = useRelatedProducts<TObject>(props);

--- a/packages/recommend-react/src/RelatedProducts.tsx
+++ b/packages/recommend-react/src/RelatedProducts.tsx
@@ -1,7 +1,7 @@
 import { GetRelatedProductsProps } from '@algolia/recommend-core';
 import {
   createRelatedProductsComponent,
-  RelatedProductsProps as RelatedProductsVDomProps,
+  RelatedProductsProps as RelatedProductsVDOMProps,
 } from '@algolia/recommend-vdom';
 import React, { createElement, Fragment } from 'react';
 
@@ -13,7 +13,7 @@ const UncontrolledRelatedProducts = createRelatedProductsComponent({
 });
 
 type RelatedProductsProps<TObject> = GetRelatedProductsProps<TObject> &
-  Omit<RelatedProductsVDomProps<TObject>, 'items'>;
+  Omit<RelatedProductsVDOMProps<TObject>, 'items'>;
 
 export function RelatedProducts<TObject>(props: RelatedProductsProps<TObject>) {
   const { recommendations } = useRelatedProducts<TObject>(props);

--- a/packages/recommend-vdom/src/FrequentlyBoughtTogether.tsx
+++ b/packages/recommend-vdom/src/FrequentlyBoughtTogether.tsx
@@ -1,6 +1,4 @@
 /** @jsx createElement */
-import { GetFrequentlyBoughtTogetherProps } from '@algolia/recommend-core';
-
 import { createDefaultChildrenComponent } from './DefaultChildren';
 import { createDefaultFallbackComponent } from './DefaultFallback';
 import { createDefaultHeaderComponent } from './DefaultHeader';
@@ -13,8 +11,7 @@ import {
 
 export type FrequentlyBoughtTogetherProps<
   TObject
-> = GetFrequentlyBoughtTogetherProps<TObject> &
-  RecommendComponentProps<TObject>;
+> = RecommendComponentProps<TObject>;
 
 export function createFrequentlyBoughtTogetherComponent({
   createElement,

--- a/packages/recommend-vdom/src/RelatedProducts.tsx
+++ b/packages/recommend-vdom/src/RelatedProducts.tsx
@@ -1,6 +1,4 @@
 /** @jsx createElement */
-import { GetRelatedProductsProps } from '@algolia/recommend-core';
-
 import { createDefaultChildrenComponent } from './DefaultChildren';
 import { createDefaultFallbackComponent } from './DefaultFallback';
 import { createDefaultHeaderComponent } from './DefaultHeader';
@@ -11,8 +9,7 @@ import {
   Renderer,
 } from './types';
 
-export type RelatedProductsProps<TObject> = GetRelatedProductsProps<TObject> &
-  RecommendComponentProps<TObject>;
+export type RelatedProductsProps<TObject> = RecommendComponentProps<TObject>;
 
 export function createRelatedProductsComponent({
   createElement,


### PR DESCRIPTION
This fixes a typing issue raised by the Dashboard team where `items` was marked as required in our FBT and RP components.

We forgot to omit the `items` prop which is only used by the VDOM components.

I took the opportunity to fix other typing inconsistencies where we expected the VDOM component to receive `GetRelatedProductsProps`, whereas it's only expect at the renderer packages' level (React and JS).