### PR TITLE
fix(fallbackFilters): rename `fallbackFilters` to `fallbackParameters`

### DIFF
--- a/examples/demo/src/App.js
+++ b/examples/demo/src/App.js
@@ -170,9 +170,11 @@ function App() {
                 translations={{
                   title: 'Related products (fallback)',
                 }}
-                fallbackFilters={[
-                  `hierarchical_categories.lvl2:${selectedProduct.hierarchical_categories.lvl2}`,
-                ]}
+                fallbackParameters={{
+                  facetFilters: [
+                    `hierarchical_categories.lvl2:${selectedProduct.hierarchical_categories.lvl2}`,
+                  ],
+                }}
                 searchParameters={{
                   analytics: true,
                   clickAnalytics: true,
@@ -194,9 +196,11 @@ function App() {
             translations={{
               title: 'Related products',
             }}
-            fallbackFilters={[
-              `hierarchical_categories.lvl2:${selectedProduct.hierarchical_categories.lvl2}`,
-            ]}
+            fallbackParameters={{
+              facetFilters: [
+                `hierarchical_categories.lvl2:${selectedProduct.hierarchical_categories.lvl2}`,
+              ],
+            }}
             searchParameters={{
               analytics: true,
               clickAnalytics: true,

--- a/examples/js-demo/app.js
+++ b/examples/js-demo/app.js
@@ -180,9 +180,11 @@ function renderRecommendations(selectedProduct) {
         translations: {
           title: 'Related products (fallback)',
         },
-        fallbackFilters: [
-          `hierarchical_categories.lvl2:${selectedProduct.hierarchical_categories.lvl2}`,
-        ],
+        fallbackParameters: {
+          facetFilters: [
+            `hierarchical_categories.lvl2:${selectedProduct.hierarchical_categories.lvl2}`,
+          ],
+        },
         searchParameters: {
           analytics: true,
           clickAnalytics: true,
@@ -213,9 +215,11 @@ function renderRecommendations(selectedProduct) {
     translations: {
       title: 'Related products',
     },
-    fallbackFilters: [
-      `hierarchical_categories.lvl2:${selectedProduct.hierarchical_categories.lvl2}`,
-    ],
+    fallbackParameters: {
+      facetFilters: [
+        `hierarchical_categories.lvl2:${selectedProduct.hierarchical_categories.lvl2}`,
+      ],
+    },
     searchParameters: {
       analytics: true,
       clickAnalytics: true,

--- a/packages/recommend-core/src/__tests__/getRecommendations.test.ts
+++ b/packages/recommend-core/src/__tests__/getRecommendations.test.ts
@@ -3,7 +3,7 @@ import {
   createSearchClient,
 } from '../../../../test/utils';
 import { getRecommendations } from '../getRecommendations';
-import { RecommendationModel } from '../types';
+import { RecommendModel } from '../types';
 
 const hit = {
   name: 'Landoh 4-Pocket Jumpsuit',
@@ -59,7 +59,7 @@ describe('getRecommendations', () => {
   test('calls the correct index for "related-products"', async () => {
     const { index, searchClient } = createRecommendationsClient();
     const props = {
-      model: 'related-products' as RecommendationModel,
+      model: 'related-products' as RecommendModel,
       searchClient: searchClient as any,
       indexName: 'indexName',
       objectIDs: ['objectID'],
@@ -107,7 +107,7 @@ describe('getRecommendations', () => {
   test('calls the correct index for "bought-together"', async () => {
     const { index, searchClient } = createRecommendationsClient();
     const props = {
-      model: 'bought-together' as RecommendationModel,
+      model: 'bought-together' as RecommendModel,
       searchClient: searchClient as any,
       indexName: 'indexName',
       objectIDs: ['objectID'],
@@ -153,10 +153,66 @@ describe('getRecommendations', () => {
   test('returns recommended hits', async () => {
     const { searchClient } = createRecommendationsClient();
     const props = {
-      model: 'related-products' as RecommendationModel,
+      model: 'related-products' as RecommendModel,
       searchClient: searchClient as any,
       indexName: 'indexName',
       objectIDs: ['objectID'],
+    };
+
+    const { recommendations } = await getRecommendations(props);
+
+    expect(recommendations).toEqual([
+      {
+        __indexName: 'indexName',
+        __position: 1,
+        __queryID: undefined,
+        __recommendScore: null,
+        category: 'Women - Jumpsuits-Overalls',
+        hierarchical_categories: {
+          lvl0: 'women',
+          lvl1: 'women > jeans & bottoms',
+          lvl2: 'women > jeans & bottoms > jumpsuits & overalls',
+        },
+        keywords: [
+          'women',
+          'jeans & bottoms',
+          'jumpsuits & overalls',
+          'Jumpsuits',
+          'Loose',
+          'Woven',
+          'Long sleeve',
+          'Grey',
+        ],
+        name: 'Landoh 4-Pocket Jumpsuit',
+        objectID: 'D06270-9132-995',
+        price: 250,
+        recommendations: [
+          {
+            objectID: '1',
+            score: 1.99,
+          },
+          {
+            objectID: '2',
+            score: 2.99,
+          },
+          {
+            objectID: '3',
+            score: 3.99,
+          },
+        ],
+        url: 'women/jumpsuits-overalls/d06270-9132-995',
+      },
+    ]);
+  });
+
+  test('does not throw with empty `fallbackParameters`', async () => {
+    const { searchClient } = createRecommendationsClient();
+    const props = {
+      model: 'related-products' as RecommendModel,
+      searchClient: searchClient as any,
+      indexName: 'indexName',
+      objectIDs: ['objectID'],
+      fallbackParameters: {},
     };
 
     const { recommendations } = await getRecommendations(props);

--- a/packages/recommend-core/src/getFrequentlyBoughtTogether.ts
+++ b/packages/recommend-core/src/getFrequentlyBoughtTogether.ts
@@ -5,7 +5,7 @@ import {
 
 export type GetFrequentlyBoughtTogetherProps<TObject> = Omit<
   GetRecommendationsProps<TObject>,
-  'model' | 'fallbackFilters'
+  'model' | 'fallbackParameters'
 >;
 
 export function getFrequentlyBoughtTogether<TObject>(
@@ -13,7 +13,7 @@ export function getFrequentlyBoughtTogether<TObject>(
 ) {
   const props: GetRecommendationsProps<TObject> = {
     ...userProps,
-    fallbackFilters: [],
+    fallbackParameters: { facetFilters: [] },
     model: 'bought-together',
   };
 

--- a/packages/recommend-core/src/getRecommendations.ts
+++ b/packages/recommend-core/src/getRecommendations.ts
@@ -37,7 +37,7 @@ export type GetRecommendationsProps<TObject> = {
 
 export type GetRecommendationsInternalProps<TObject> = Required<
   GetRecommendationsProps<TObject>
->;
+> & { fallbackParameters: Required<Pick<SearchOptions, 'facetFilters'>> };
 
 export type GetRecommendationsResult<TObject> = {
   recommendations: Array<RecordWithObjectID<TObject>>;
@@ -47,11 +47,13 @@ function getDefaultedProps<TObject>(
   props: GetRecommendationsProps<TObject>
 ): GetRecommendationsInternalProps<TObject> {
   return {
-    fallbackParameters: { facetFilters: [] },
     maxRecommendations: 0,
     threshold: 0,
     transformItems: (items) => items,
     ...props,
+    fallbackParameters: {
+      facetFilters: props.fallbackParameters?.facetFilters || [],
+    },
     searchParameters: {
       analytics: false,
       analyticsTags: [`alg-recommend_${props.model}`],

--- a/packages/recommend-core/src/getRecommendations.ts
+++ b/packages/recommend-core/src/getRecommendations.ts
@@ -20,24 +20,34 @@ type RecommendedRecord = RecordWithObjectID<{
   recommendations?: RecommendRecord[];
 }>;
 
+export type RecommendSearchParameters = Omit<
+  SearchOptions,
+  'page' | 'hitsPerPage' | 'offset' | 'length'
+>;
+
 export type GetRecommendationsProps<TObject> = {
   model: RecommendModel;
   indexName: string;
   objectIDs: string[];
   searchClient: SearchClient;
 
-  fallbackParameters?: Pick<SearchOptions, 'facetFilters'>;
+  fallbackParameters?: RecommendSearchParameters;
   maxRecommendations?: number;
-  searchParameters?: SearchOptions;
+  searchParameters?: RecommendSearchParameters;
   threshold?: number;
   transformItems?: (
     items: Array<ProductRecord<TObject>>
   ) => Array<ProductRecord<TObject>>;
 };
 
+type GetRecommendationsInternalSearchParameters = RecommendSearchParameters &
+  Required<Pick<RecommendSearchParameters, 'facetFilters'>>;
+
 export type GetRecommendationsInternalProps<TObject> = Required<
   GetRecommendationsProps<TObject>
-> & { fallbackParameters: Required<Pick<SearchOptions, 'facetFilters'>> };
+> & {
+  fallbackParameters: GetRecommendationsInternalSearchParameters;
+};
 
 export type GetRecommendationsResult<TObject> = {
   recommendations: Array<RecordWithObjectID<TObject>>;
@@ -52,7 +62,8 @@ function getDefaultedProps<TObject>(
     transformItems: (items) => items,
     ...props,
     fallbackParameters: {
-      facetFilters: props.fallbackParameters?.facetFilters || [],
+      facetFilters: [],
+      ...props.fallbackParameters,
     },
     searchParameters: {
       analytics: false,

--- a/packages/recommend-core/src/getRecommendations.ts
+++ b/packages/recommend-core/src/getRecommendations.ts
@@ -26,7 +26,7 @@ export type GetRecommendationsProps<TObject> = {
   objectIDs: string[];
   searchClient: SearchClient;
 
-  fallbackFilters?: SearchOptions['optionalFilters'];
+  fallbackParameters?: { facetFilters: SearchOptions['facetFilters'] };
   maxRecommendations?: number;
   searchParameters?: SearchOptions;
   threshold?: number;
@@ -47,7 +47,7 @@ function getDefaultedProps<TObject>(
   props: GetRecommendationsProps<TObject>
 ): GetRecommendationsInternalProps<TObject> {
   return {
-    fallbackFilters: [],
+    fallbackParameters: { facetFilters: [] },
     maxRecommendations: 0,
     threshold: 0,
     transformItems: (items) => items,
@@ -90,7 +90,7 @@ export function getRecommendations<TObject>(
             // This computes the `hitsPerPage` value as if a single `objectID`
             // was passed.
             const globalHitsPerPage = getHitsPerPage({
-              fallbackFilters: props.fallbackFilters,
+              fallbackParameters: props.fallbackParameters,
               maxRecommendations: props.maxRecommendations,
               recommendationsCount: recommendations.length,
             });
@@ -101,7 +101,7 @@ export function getRecommendations<TObject>(
                 ? Math.ceil(globalHitsPerPage / props.objectIDs.length)
                 : globalHitsPerPage;
             const searchParametersForModel = getSearchParametersForModel({
-              fallbackFilters: props.fallbackFilters,
+              fallbackParameters: props.fallbackParameters,
               recommendations,
               threshold: props.threshold,
             })(props.model);

--- a/packages/recommend-core/src/getRecommendations.ts
+++ b/packages/recommend-core/src/getRecommendations.ts
@@ -26,7 +26,7 @@ export type GetRecommendationsProps<TObject> = {
   objectIDs: string[];
   searchClient: SearchClient;
 
-  fallbackParameters?: { facetFilters: SearchOptions['facetFilters'] };
+  fallbackParameters?: Pick<SearchOptions, 'facetFilters'>;
   maxRecommendations?: number;
   searchParameters?: SearchOptions;
   threshold?: number;

--- a/packages/recommend-core/src/utils/getHitsPerPage.ts
+++ b/packages/recommend-core/src/utils/getHitsPerPage.ts
@@ -11,7 +11,7 @@ export function getHitsPerPage<TObject>({
   maxRecommendations,
   recommendationsCount,
 }: GetHitsPerPageParams<TObject>) {
-  const hasFallback = fallbackParameters.facetFilters!.length > 0;
+  const hasFallback = fallbackParameters.facetFilters.length > 0;
 
   if (recommendationsCount === 0) {
     return hasFallback ? maxRecommendations : 0;

--- a/packages/recommend-core/src/utils/getHitsPerPage.ts
+++ b/packages/recommend-core/src/utils/getHitsPerPage.ts
@@ -1,17 +1,17 @@
 import { GetRecommendationsInternalProps } from '../getRecommendations';
 
 type GetHitsPerPageParams<TObject> = {
-  fallbackFilters: GetRecommendationsInternalProps<TObject>['fallbackFilters'];
+  fallbackParameters: GetRecommendationsInternalProps<TObject>['fallbackParameters'];
   maxRecommendations: GetRecommendationsInternalProps<TObject>['maxRecommendations'];
   recommendationsCount: number;
 };
 
 export function getHitsPerPage<TObject>({
-  fallbackFilters,
+  fallbackParameters,
   maxRecommendations,
   recommendationsCount,
 }: GetHitsPerPageParams<TObject>) {
-  const hasFallback = fallbackFilters.length > 0;
+  const hasFallback = fallbackParameters.facetFilters!.length > 0;
 
   if (recommendationsCount === 0) {
     return hasFallback ? maxRecommendations : 0;

--- a/packages/recommend-core/src/utils/getSearchParametersForModel.ts
+++ b/packages/recommend-core/src/utils/getSearchParametersForModel.ts
@@ -22,7 +22,7 @@ function getFiltersFromRecommendations<TObject>({
     .filter((recommendation) => recommendation.score > threshold)
     .map(({ objectID, score }) => `objectID:${objectID}<score=${score * 100}>`);
 
-  return [...recommendationFilters, ...fallbackParameters.facetFilters!];
+  return [...recommendationFilters, ...fallbackParameters.facetFilters];
 }
 
 function getSearchParametersForRelatedProducts<TObject>({
@@ -44,7 +44,7 @@ function getSearchParametersForFrequentlyBoughtTogether<TObject>({
   recommendations,
   threshold,
 }: GetSearchParametersParams<TObject>): SearchOptions {
-  if (fallbackParameters.facetFilters!.length === 0) {
+  if (fallbackParameters.facetFilters.length === 0) {
     return {
       // We want strict recommendations for FBT when there's no fallback because
       // we cannot guess what products were bought with the reference product.

--- a/packages/recommend-core/src/utils/getSearchParametersForModel.ts
+++ b/packages/recommend-core/src/utils/getSearchParametersForModel.ts
@@ -4,35 +4,35 @@ import { GetRecommendationsInternalProps } from '../getRecommendations';
 import { RecommendModel, RecommendRecord } from '../types';
 
 type GetSearchParametersParams<TObject> = {
-  fallbackFilters: GetRecommendationsInternalProps<TObject>['fallbackFilters'];
+  fallbackParameters: GetRecommendationsInternalProps<TObject>['fallbackParameters'];
   recommendations: RecommendRecord[];
   threshold: GetRecommendationsInternalProps<TObject>['threshold'];
 };
 
 function getFiltersFromRecommendations<TObject>({
-  fallbackFilters,
+  fallbackParameters,
   recommendations,
   threshold,
 }: GetSearchParametersParams<TObject>): SearchOptions['optionalFilters'] {
   if (recommendations.length === 0) {
-    return fallbackFilters;
+    return fallbackParameters.facetFilters;
   }
 
   const recommendationFilters = recommendations
     .filter((recommendation) => recommendation.score > threshold)
     .map(({ objectID, score }) => `objectID:${objectID}<score=${score * 100}>`);
 
-  return [...recommendationFilters, ...fallbackFilters];
+  return [...recommendationFilters, ...fallbackParameters.facetFilters!];
 }
 
 function getSearchParametersForRelatedProducts<TObject>({
-  fallbackFilters,
+  fallbackParameters,
   recommendations,
   threshold,
 }: GetSearchParametersParams<TObject>): SearchOptions {
   return {
     optionalFilters: getFiltersFromRecommendations({
-      fallbackFilters,
+      fallbackParameters,
       recommendations,
       threshold,
     }),
@@ -40,11 +40,11 @@ function getSearchParametersForRelatedProducts<TObject>({
 }
 
 function getSearchParametersForFrequentlyBoughtTogether<TObject>({
-  fallbackFilters,
+  fallbackParameters,
   recommendations,
   threshold,
 }: GetSearchParametersParams<TObject>): SearchOptions {
-  if (fallbackFilters.length === 0) {
+  if (fallbackParameters.facetFilters!.length === 0) {
     return {
       // We want strict recommendations for FBT when there's no fallback because
       // we cannot guess what products were bought with the reference product.
@@ -58,7 +58,7 @@ function getSearchParametersForFrequentlyBoughtTogether<TObject>({
 
   return {
     optionalFilters: getFiltersFromRecommendations({
-      fallbackFilters,
+      fallbackParameters,
       recommendations,
       threshold,
     }),

--- a/packages/recommend-js/README.md
+++ b/packages/recommend-js/README.md
@@ -353,7 +353,7 @@ The number of recommendations to retrieve.
 
 ### `fallbackParameters`
 
-> `{ facetFilters: string | string[] | Array<string[]> }`
+> `Omit<SearchOptions, 'page' | 'hitsPerPage' | 'offset' | 'length'>`
 
 Additional filters to use as fallback when there is not enough recommendations.
 

--- a/packages/recommend-js/README.md
+++ b/packages/recommend-js/README.md
@@ -351,11 +351,11 @@ An array of `objectID`s of the products to get recommendations from.
 
 The number of recommendations to retrieve.
 
-### `fallbackFilters`
+### `fallbackParameters`
 
-> list of strings
+> `{ facetFilters: string | string[] | Array<string[]> }`
 
-Additional filters to use as fallback should there not be enough recommendations.
+Additional filters to use as fallback when there is not enough recommendations.
 
 ### `searchParameters`
 

--- a/packages/recommend-react/README.md
+++ b/packages/recommend-react/README.md
@@ -519,7 +519,7 @@ function defaultRender(props) {
 
 ## `useFrequentlyBoughtTogether`
 
-> [`(props: Omit<SharedProps, 'fallbackFilters'>) => { recommendations }`](#shared-props)
+> [`(props: Omit<SharedProps, 'fallbackParameters'>) => { recommendations }`](#shared-props)
 
 Hook to retrieve frequently bought together products.
 
@@ -646,11 +646,11 @@ An array of `objectID`s of the products to get recommendations from.
 
 The number of recommendations to retrieve.
 
-### `fallbackFilters`
+### `fallbackParameters`
 
-> list of strings
+> `{ facetFilters: string | string[] | Array<string[]> }`
 
-Additional filters to use as fallback should there not be enough recommendations.
+Additional filters to use as fallback when there is not enough recommendations.
 
 ### `searchParameters`
 

--- a/packages/recommend-react/README.md
+++ b/packages/recommend-react/README.md
@@ -648,7 +648,7 @@ The number of recommendations to retrieve.
 
 ### `fallbackParameters`
 
-> `{ facetFilters: string | string[] | Array<string[]> }`
+> `Omit<SearchOptions, 'page' | 'hitsPerPage' | 'offset' | 'length'>`
 
 Additional filters to use as fallback when there is not enough recommendations.
 


### PR DESCRIPTION
**Summary**

`fallbackFilters` will be named `fallbackParameters`  after the GA release, its structure also changed since it will accept `searchParameters`, but we only handle `facetFilters` for now.
