### PR TITLE
fix(recommend): only sort items with scores

### DIFF
--- a/packages/recommend-core/src/utils/__tests__/mapToRecommendations.test.ts
+++ b/packages/recommend-core/src/utils/__tests__/mapToRecommendations.test.ts
@@ -1,0 +1,129 @@
+import { mapToRecommendations } from '../mapToRecommendations';
+
+const response = {
+  results: [
+    {
+      exhaustiveNbHits: true,
+      hits: [
+        {
+          objectID: '1-1',
+          name: 'Product 1-1',
+          _score: 100,
+        },
+        {
+          objectID: '1-2',
+          name: 'Product 1-2',
+          _score: 90,
+        },
+        {
+          objectID: '1-3',
+          name: 'Product 1-3',
+          _score: 70,
+        },
+        {
+          objectID: '1-4',
+          name: 'Product 1-4',
+        },
+        {
+          objectID: '1-5',
+          name: 'Product 1-5',
+        },
+      ],
+      hitsPerPage: 10,
+      nbHits: 10,
+      nbPages: 1,
+      page: 0,
+      processingTimeMS: 1,
+    },
+    {
+      exhaustiveNbHits: true,
+      hits: [
+        {
+          objectID: '2-1',
+          name: 'Product 2-1',
+          _score: 100,
+        },
+        {
+          objectID: '2-2',
+          name: 'Product 2-2',
+          _score: 90,
+        },
+        {
+          objectID: '2-3',
+          name: 'Product 2-3',
+          _score: 70,
+        },
+        {
+          objectID: '2-4',
+          name: 'Product 2-4',
+        },
+        {
+          objectID: '2-5',
+          name: 'Product 2-5',
+        },
+      ],
+      hitsPerPage: 10,
+      nbHits: 10,
+      nbPages: 1,
+      page: 0,
+      processingTimeMS: 1,
+    },
+  ],
+};
+
+describe('mapToRecommendations', () => {
+  test('sorts the items based on their scores', () => {
+    const result = mapToRecommendations({ response: response as any });
+
+    expect(result).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "_score": 100,
+          "name": "Product 1-1",
+          "objectID": "1-1",
+        },
+        Object {
+          "_score": 100,
+          "name": "Product 2-1",
+          "objectID": "2-1",
+        },
+        Object {
+          "_score": 90,
+          "name": "Product 1-2",
+          "objectID": "1-2",
+        },
+        Object {
+          "_score": 90,
+          "name": "Product 2-2",
+          "objectID": "2-2",
+        },
+        Object {
+          "_score": 70,
+          "name": "Product 1-3",
+          "objectID": "1-3",
+        },
+        Object {
+          "_score": 70,
+          "name": "Product 2-3",
+          "objectID": "2-3",
+        },
+        Object {
+          "name": "Product 1-4",
+          "objectID": "1-4",
+        },
+        Object {
+          "name": "Product 1-5",
+          "objectID": "1-5",
+        },
+        Object {
+          "name": "Product 2-4",
+          "objectID": "2-4",
+        },
+        Object {
+          "name": "Product 2-5",
+          "objectID": "2-5",
+        },
+      ]
+    `);
+  });
+});

--- a/packages/recommend-core/src/utils/mapToRecommendations.ts
+++ b/packages/recommend-core/src/utils/mapToRecommendations.ts
@@ -21,7 +21,7 @@ export function mapToRecommendations<TObject>({
       const scoreA = a._score || 0;
       const scoreB = b._score || 0;
 
-      return scoreA < scoreB ? 1 : -1;
+      return scoreA > scoreB ? -1 : 1;
     },
     // Multiple identical recommended `objectID`s can be returned b
     // the engine, so we need to remove duplicates.


### PR DESCRIPTION
This fixes cases where non-scored items are re-sorted because of our `sortBy` logic:

![image](https://user-images.githubusercontent.com/6137112/123609163-b6e49c80-d7ff-11eb-8220-c3ca3f1ca4fd.png)

Notice that the items with `undefined` as score were re-sorted.

I reversed the `sortBy` predicate, and now only sort items if their score are different, otherwise keep the order returned by the engine.

