### PR TITLE
feat(recommend): add status state (loading, stalled, idle)

### DIFF
--- a/packages/recommend-js/src/frequentlyBoughtTogether.tsx
+++ b/packages/recommend-js/src/frequentlyBoughtTogether.tsx
@@ -14,6 +14,7 @@ import { useEffect, useState } from 'preact/hooks';
 import { getHTMLElement } from './getHTMLElement';
 import { EnvironmentProps } from './types';
 import { useAlgoliaAgent } from './useAlgoliaAgent';
+import { useStatus } from './useStatus';
 
 const UncontrolledFrequentlyBoughtTogether = createFrequentlyBoughtTogetherComponent(
   {
@@ -28,30 +29,42 @@ function useFrequentlyBoughtTogether<TObject>(
   const [result, setResult] = useState<GetRecommendationsResult<TObject>>({
     recommendations: [],
   });
+  const { status, setStatus } = useStatus('loading');
 
   useAlgoliaAgent({ recommendClient: props.recommendClient });
 
   useEffect(() => {
+    setStatus('loading');
     getFrequentlyBoughtTogether(props).then((response) => {
       setResult(response);
+      setStatus('idle');
     });
-  }, [props]);
+  }, [props, setStatus]);
 
-  return result;
+  return {
+    ...result,
+    status,
+  };
 }
 
 type FrequentlyBoughtTogetherProps<
   TObject
 > = GetFrequentlyBoughtTogetherProps<TObject> &
-  Omit<FrequentlyBoughtTogetherVDOMProps<TObject>, 'items'>;
+  Omit<FrequentlyBoughtTogetherVDOMProps<TObject>, 'items' | 'status'>;
 
 function FrequentlyBoughtTogether<TObject>(
   props: FrequentlyBoughtTogetherProps<TObject>
 ) {
-  const { recommendations } = useFrequentlyBoughtTogether<TObject>(props);
+  const { recommendations, status } = useFrequentlyBoughtTogether<TObject>(
+    props
+  );
 
   return (
-    <UncontrolledFrequentlyBoughtTogether {...props} items={recommendations} />
+    <UncontrolledFrequentlyBoughtTogether
+      {...props}
+      items={recommendations}
+      status={status}
+    />
   );
 }
 

--- a/packages/recommend-js/src/useStatus.ts
+++ b/packages/recommend-js/src/useStatus.ts
@@ -1,6 +1,8 @@
 import { RecommendStatus } from '@algolia/recommend-vdom';
 import { useEffect, useRef, useState } from 'preact/hooks';
 
+// If you update this logic, please also update the implementation in the
+// `recommend-react` package.
 export function useStatus(initialStatus: RecommendStatus) {
   const timerId = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const [status, setStatus] = useState<RecommendStatus>(initialStatus);

--- a/packages/recommend-js/src/useStatus.ts
+++ b/packages/recommend-js/src/useStatus.ts
@@ -1,0 +1,21 @@
+import { RecommendStatus } from '@algolia/recommend-vdom';
+import { useEffect, useRef, useState } from 'preact/hooks';
+
+export function useStatus(initialStatus: RecommendStatus) {
+  const timerId = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const [status, setStatus] = useState<RecommendStatus>(initialStatus);
+
+  useEffect(() => {
+    if (status !== 'stalled' && timerId.current) {
+      clearTimeout(timerId.current);
+    }
+
+    if (status === 'loading') {
+      timerId.current = setTimeout(() => {
+        setStatus('stalled');
+      }, 300);
+    }
+  }, [status]);
+
+  return { status, setStatus };
+}

--- a/packages/recommend-react/src/FrequentlyBoughtTogether.tsx
+++ b/packages/recommend-react/src/FrequentlyBoughtTogether.tsx
@@ -17,14 +17,20 @@ const UncontrolledFrequentlyBoughtTogether = createFrequentlyBoughtTogetherCompo
 type FrequentlyBoughtTogetherProps<
   TObject
 > = GetFrequentlyBoughtTogetherProps<TObject> &
-  Omit<FrequentlyBoughtTogetherVDOMProps<TObject>, 'items'>;
+  Omit<FrequentlyBoughtTogetherVDOMProps<TObject>, 'items' | 'status'>;
 
 export function FrequentlyBoughtTogether<TObject>(
   props: FrequentlyBoughtTogetherProps<TObject>
 ) {
-  const { recommendations } = useFrequentlyBoughtTogether<TObject>(props);
+  const { recommendations, status } = useFrequentlyBoughtTogether<TObject>(
+    props
+  );
 
   return (
-    <UncontrolledFrequentlyBoughtTogether {...props} items={recommendations} />
+    <UncontrolledFrequentlyBoughtTogether
+      {...props}
+      items={recommendations}
+      status={status}
+    />
   );
 }

--- a/packages/recommend-react/src/RelatedProducts.tsx
+++ b/packages/recommend-react/src/RelatedProducts.tsx
@@ -13,10 +13,16 @@ const UncontrolledRelatedProducts = createRelatedProductsComponent({
 });
 
 type RelatedProductsProps<TObject> = GetRelatedProductsProps<TObject> &
-  Omit<RelatedProductsVDOMProps<TObject>, 'items'>;
+  Omit<RelatedProductsVDOMProps<TObject>, 'items' | 'status'>;
 
 export function RelatedProducts<TObject>(props: RelatedProductsProps<TObject>) {
-  const { recommendations } = useRelatedProducts<TObject>(props);
+  const { recommendations, status } = useRelatedProducts<TObject>(props);
 
-  return <UncontrolledRelatedProducts {...props} items={recommendations} />;
+  return (
+    <UncontrolledRelatedProducts
+      {...props}
+      items={recommendations}
+      status={status}
+    />
+  );
 }

--- a/packages/recommend-react/src/useFrequentlyBoughtTogether.ts
+++ b/packages/recommend-react/src/useFrequentlyBoughtTogether.ts
@@ -6,6 +6,7 @@ import {
 import { useEffect, useState } from 'react';
 
 import { useAlgoliaAgent } from './useAlgoliaAgent';
+import { useStatus } from './useStatus';
 
 export function useFrequentlyBoughtTogether<TObject>(
   props: GetFrequentlyBoughtTogetherProps<TObject>
@@ -13,14 +14,20 @@ export function useFrequentlyBoughtTogether<TObject>(
   const [result, setResult] = useState<GetRecommendationsResult<TObject>>({
     recommendations: [],
   });
+  const { status, setStatus } = useStatus('loading');
 
   useAlgoliaAgent({ recommendClient: props.recommendClient });
 
   useEffect(() => {
+    setStatus('loading');
     getFrequentlyBoughtTogether(props).then((response) => {
       setResult(response);
+      setStatus('idle');
     });
-  }, [props]);
+  }, [props, setStatus]);
 
-  return result;
+  return {
+    ...result,
+    status,
+  };
 }

--- a/packages/recommend-react/src/useRecommendations.ts
+++ b/packages/recommend-react/src/useRecommendations.ts
@@ -6,6 +6,7 @@ import {
 import { useEffect, useState } from 'react';
 
 import { useAlgoliaAgent } from './useAlgoliaAgent';
+import { useStatus } from './useStatus';
 
 export function useRecommendations<TObject>(
   props: GetRecommendationsProps<TObject>
@@ -13,14 +14,20 @@ export function useRecommendations<TObject>(
   const [result, setResult] = useState<GetRecommendationsResult<TObject>>({
     recommendations: [],
   });
+  const { status, setStatus } = useStatus('loading');
 
   useAlgoliaAgent({ recommendClient: props.recommendClient });
 
   useEffect(() => {
+    setStatus('loading');
     getRecommendations(props).then((response) => {
       setResult(response);
+      setStatus('idle');
     });
-  }, [props]);
+  }, [props, setStatus]);
 
-  return result;
+  return {
+    ...result,
+    status,
+  };
 }

--- a/packages/recommend-react/src/useRelatedProducts.ts
+++ b/packages/recommend-react/src/useRelatedProducts.ts
@@ -6,6 +6,7 @@ import {
 import { useEffect, useState } from 'react';
 
 import { useAlgoliaAgent } from './useAlgoliaAgent';
+import { useStatus } from './useStatus';
 
 export function useRelatedProducts<TObject>(
   props: GetRelatedProductsProps<TObject>
@@ -13,14 +14,20 @@ export function useRelatedProducts<TObject>(
   const [result, setResult] = useState<GetRecommendationsResult<TObject>>({
     recommendations: [],
   });
+  const { status, setStatus } = useStatus('loading');
 
   useAlgoliaAgent({ recommendClient: props.recommendClient });
 
   useEffect(() => {
+    setStatus('loading');
     getRelatedProducts(props).then((response) => {
       setResult(response);
+      setStatus('idle');
     });
-  }, [props]);
+  }, [props, setStatus]);
 
-  return result;
+  return {
+    ...result,
+    status,
+  };
 }

--- a/packages/recommend-react/src/useStatus.ts
+++ b/packages/recommend-react/src/useStatus.ts
@@ -1,0 +1,21 @@
+import { RecommendStatus } from '@algolia/recommend-vdom';
+import { useEffect, useRef, useState } from 'react';
+
+export function useStatus(initialStatus: RecommendStatus) {
+  const timerId = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const [status, setStatus] = useState<RecommendStatus>(initialStatus);
+
+  useEffect(() => {
+    if (status !== 'stalled' && timerId.current) {
+      clearTimeout(timerId.current);
+    }
+
+    if (status === 'loading') {
+      timerId.current = setTimeout(() => {
+        setStatus('stalled');
+      }, 300);
+    }
+  }, [status]);
+
+  return { status, setStatus };
+}

--- a/packages/recommend-react/src/useStatus.ts
+++ b/packages/recommend-react/src/useStatus.ts
@@ -1,6 +1,8 @@
 import { RecommendStatus } from '@algolia/recommend-vdom';
 import { useEffect, useRef, useState } from 'react';
 
+// If you update this logic, please also update the implementation in the
+// `recommend-js` package.
 export function useStatus(initialStatus: RecommendStatus) {
   const timerId = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const [status, setStatus] = useState<RecommendStatus>(initialStatus);

--- a/packages/recommend-vdom/src/DefaultChildren.tsx
+++ b/packages/recommend-vdom/src/DefaultChildren.tsx
@@ -5,7 +5,7 @@ import { cx } from './utils';
 
 export function createDefaultChildrenComponent({ createElement }: Renderer) {
   return function DefaultChildren<TObject>(props: ChildrenProps<TObject>) {
-    if (props.recommendations.length === 0) {
+    if (props.recommendations.length === 0 && props.status === 'idle') {
       return <props.Fallback />;
     }
 

--- a/packages/recommend-vdom/src/FrequentlyBoughtTogether.tsx
+++ b/packages/recommend-vdom/src/FrequentlyBoughtTogether.tsx
@@ -52,6 +52,7 @@ export function createFrequentlyBoughtTogetherComponent({
       Fallback,
       Header,
       recommendations: props.items,
+      status: props.status,
       translations,
       View,
     });

--- a/packages/recommend-vdom/src/RelatedProducts.tsx
+++ b/packages/recommend-vdom/src/RelatedProducts.tsx
@@ -50,6 +50,7 @@ export function createRelatedProductsComponent({
       Fallback,
       Header,
       recommendations: props.items,
+      status: props.status,
       translations,
       View,
     });

--- a/packages/recommend-vdom/src/types/RecommendComponentProps.ts
+++ b/packages/recommend-vdom/src/types/RecommendComponentProps.ts
@@ -1,6 +1,7 @@
 import { RecordWithObjectID } from '@algolia/recommend-core';
 
 import { RecommendClassNames } from './RecommendClassNames';
+import { RecommendStatus } from './RecommendStatus';
 import { RecommendTranslations } from './RecommendTranslations';
 import { ViewProps } from './ViewProps';
 
@@ -13,6 +14,7 @@ export type ComponentProps<TObject> = {
 export type ChildrenProps<TObject> = ComponentProps<TObject> & {
   Fallback(): JSX.Element | null;
   Header(props: ComponentProps<TObject>): JSX.Element | null;
+  status: RecommendStatus;
   View(props: unknown): JSX.Element;
 };
 
@@ -23,6 +25,7 @@ export type RecommendComponentProps<TObject> = {
   children?(props: ChildrenProps<TObject>): JSX.Element;
   fallbackComponent?(): JSX.Element;
   headerComponent?(props: ComponentProps<TObject>): JSX.Element;
+  status: RecommendStatus;
   translations?: Required<RecommendTranslations>;
   view?(
     props: ViewProps<

--- a/packages/recommend-vdom/src/types/RecommendStatus.ts
+++ b/packages/recommend-vdom/src/types/RecommendStatus.ts
@@ -1,0 +1,1 @@
+export type RecommendStatus = 'loading' | 'stalled' | 'idle';

--- a/packages/recommend-vdom/src/types/index.ts
+++ b/packages/recommend-vdom/src/types/index.ts
@@ -1,5 +1,6 @@
 export * from './RecommendTranslations';
 export * from './RecommendClassNames';
 export * from './RecommendComponentProps';
+export * from './RecommendStatus';
 export * from './Renderer';
 export * from './ViewProps';


### PR DESCRIPTION
## The problem

There was an issue where we rendered the `fallbackComponent` during first render because we checked `props.recommendations.length === 0`, which is the case before sending the request. Thus, when using `RelatedProducts` in `fallbackComponent`, it sent another request, which was unnecessary.

## This solution

This PR adds the loading status of the component in the API, and uses it to render the fallback component when there's no recommendations _and_ that the status is `idle`.

Possible statuses are `idle`, `loading` and `stalled`. The stalled status is useful to render product placeholders after `x`ms, to reduce UI flashes as opposed to rendering it when `loading`.

In the future, we might want to expose the stalled threshold value to the user, so that they can synchronize their placeholder content with other pieces on their website.

## Considerations

Notice that the `useStatus` hook in Preact and in React have an identical implementation, which is a bummer. I don't think we can use the same code here without additional tooling.