### PR TITLE
fix(release): bump packages' versions on release

### DIFF
--- a/packages/recommend-core/src/version.ts
+++ b/packages/recommend-core/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '1.0.0-experimental.2';
+export const version = '1.0.0-experimental.6';

--- a/packages/recommend-vdom/src/version.ts
+++ b/packages/recommend-vdom/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '1.0.0-experimental.2';
+export const version = '1.0.0-experimental.6';

--- a/ship.config.js
+++ b/ship.config.js
@@ -34,8 +34,10 @@ module.exports = {
     updatePackagesVersionFile({
       version,
       files: [
-        path.resolve(dir, 'packages', 'recommend-react', 'src', 'version.ts'),
+        path.resolve(dir, 'packages', 'recommend-core', 'src', 'version.ts'),
         path.resolve(dir, 'packages', 'recommend-js', 'src', 'version.ts'),
+        path.resolve(dir, 'packages', 'recommend-react', 'src', 'version.ts'),
+        path.resolve(dir, 'packages', 'recommend-vdom', 'src', 'version.ts'),
       ],
     });
   },


### PR DESCRIPTION
The `core` and `vdom` packages' versions were not bumped by Ship.js on release.