### PR TITLE
docs(core): add TSDoc

### DIFF
--- a/packages/recommend-core/src/getRecommendations.ts
+++ b/packages/recommend-core/src/getRecommendations.ts
@@ -5,8 +5,19 @@ import { mapToRecommendations } from './utils';
 import { version } from './version';
 
 export type RecommendationsProps<TObject> = {
+  /**
+   * The `objectID`s of the items to get recommendations for.
+   */
   objectIDs: string[];
+  /**
+   * The initialized Algolia recommend client.
+   */
   recommendClient: RecommendClient;
+  /**
+   * A function to transform the retrieved items before passing them to the component.
+   *
+   * It’s useful to add or remove items, change them, or reorder them.
+   */
   transformItems?: (
     items: Array<ProductRecord<TObject>>
   ) => Array<ProductRecord<TObject>>;

--- a/packages/recommend-js/src/types/EnvironmentProps.ts
+++ b/packages/recommend-js/src/types/EnvironmentProps.ts
@@ -13,6 +13,7 @@ export type EnvironmentProps = {
    * This is useful if you're using Recommend in a different context than `window`.
    *
    * @default window
+   * @link https://www.algolia.com/doc/ui-libraries/recommend/api-reference/recommend-js/frequentlyBoughtTogether/#param-environment
    */
   environment?: typeof window;
 };

--- a/packages/recommend-js/src/types/EnvironmentProps.ts
+++ b/packages/recommend-js/src/types/EnvironmentProps.ts
@@ -1,4 +1,18 @@
 export type EnvironmentProps = {
+  /**
+   * The container for the component. You can either pass a [CSS selector](https://developer.mozilla.org/docs/Web/CSS/CSS_Selectors) or an [Element](https://developer.mozilla.org/docs/Web/API/HTMLElement). If there are several containers matching the selector, it picks up the first one.
+   *
+   * When `undefined`, the function returns a JSX element for you to inject wherever you want.
+   *
+   * @link https://www.algolia.com/doc/ui-libraries/recommend/api-reference/recommend-js/frequentlyBoughtTogether/#param-container
+   */
   container?: string | HTMLElement;
+  /**
+   * The environment in which your application is running.
+   *
+   * This is useful if you're using Recommend in a different context than `window`.
+   *
+   * @default window
+   */
   environment?: typeof window;
 };


### PR DESCRIPTION
This adds the TSDoc of the Recommend library, based on the [existing documentation](https://www.algolia.com/doc/ui-libraries/recommend/api-reference/recommend-js/frequentlyBoughtTogether/#parameters).

