### PR TITLE
fix(ci): update docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ aliases:
 defaults: &defaults
   working_directory: ~/recommend
   docker:
-    - image: circleci/node:14.15.0
+    - image: cimg/node:14.15.0
 
 references:
   workspace_root: &workspace_root /tmp/workspace


### PR DESCRIPTION
**Summary**

Fixes Circle CI docker image issue: follow up of https://github.com/algolia/autocomplete/pull/752

See https://circleci.com/developer/images/image/cimg/node for more informations

TLDR: `This image is designed to supercede the legacy CircleCI Node.js image, circleci/node.`