### PR TITLE
fix(recommend): export trending methods for recommend-js

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -6,7 +6,7 @@
     },
     {
       "path": "packages/recommend-js/dist/umd/index.js",
-      "maxSize": "6.75 kB"
+      "maxSize": "7.10 kB"
     },
     {
       "path": "packages/recommend-react/dist/umd/index.js",

--- a/packages/recommend-js/src/index.ts
+++ b/packages/recommend-js/src/index.ts
@@ -1,2 +1,4 @@
 export * from './frequentlyBoughtTogether';
 export * from './relatedProducts';
+export * from './trendingFacets';
+export * from './trendingItems';


### PR DESCRIPTION
recommend-js was missing the export for trendingItems ans trendingFacets.
This was preventing us from using the trending models.