### PR TITLE
Revert "chore: release v1.3.1 (#81)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,3 @@
-## [1.3.1](https://github.com/algolia/recommend/compare/v1.3.0...v1.3.1) (2022-04-21)
-
-
-### Bug Fixes
-
-* **core:** enable recommend with rules ([#79](https://github.com/algolia/recommend/issues/79)) ([7d9bb18](https://github.com/algolia/recommend/commit/7d9bb18046f715e8bcf61bf84ae0dbf298ba095a))
-
-
-
 # [1.3.0](https://github.com/algolia/recommend/compare/v1.2.0...v1.3.0) (2022-03-28)
 
 

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@algolia/recommend-react-example",
   "description": "Recommend React example",
-  "version": "1.3.1",
+  "version": "1.3.0",
   "private": true,
   "license": "MIT",
   "scripts": {
@@ -13,7 +13,7 @@
     "@algolia/autocomplete-theme-classic": "1.2.1",
     "@algolia/client-search": "4.10.5",
     "@algolia/recommend": "4.13.0",
-    "@algolia/recommend-react": "1.3.1",
+    "@algolia/recommend-react": "1.3.0",
     "@algolia/ui-components-horizontal-slider-react": "1.0.0",
     "@algolia/ui-components-horizontal-slider-theme": "1.0.0",
     "algoliasearch": "4.10.5",

--- a/examples/js-demo/package.json
+++ b/examples/js-demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@algolia/recommend-js-example",
   "description": "Recommend JavaScript example",
-  "version": "1.3.1",
+  "version": "1.3.0",
   "private": true,
   "license": "MIT",
   "scripts": {
@@ -13,7 +13,7 @@
     "@algolia/autocomplete-theme-classic": "1.2.1",
     "@algolia/client-search": "4.10.5",
     "@algolia/recommend": "4.13.0",
-    "@algolia/recommend-js": "1.3.1",
+    "@algolia/recommend-js": "1.3.0",
     "@algolia/ui-components-horizontal-slider-js": "1.0.0",
     "@algolia/ui-components-horizontal-slider-theme": "1.0.0",
     "@babel/runtime": "7.14.5",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "packages": ["packages/*", "examples/*"],
-  "version": "1.3.1",
+  "version": "1.3.0",
   "npmClient": "yarn"
 }

--- a/packages/recommend-core/package.json
+++ b/packages/recommend-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/recommend-core",
-  "version": "1.3.1",
+  "version": "1.3.0",
   "license": "MIT",
   "homepage": "https://github.com/algolia/recommend",
   "repository": "algolia/recommend",

--- a/packages/recommend-core/src/version.ts
+++ b/packages/recommend-core/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '1.3.1';
+export const version = '1.3.0';

--- a/packages/recommend-js/package.json
+++ b/packages/recommend-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/recommend-js",
-  "version": "1.3.1",
+  "version": "1.3.0",
   "license": "MIT",
   "homepage": "https://github.com/algolia/recommend",
   "repository": "algolia/recommend",
@@ -31,8 +31,8 @@
     "@algolia/recommend": "^4.13.0"
   },
   "dependencies": {
-    "@algolia/recommend-core": "1.3.1",
-    "@algolia/recommend-vdom": "1.3.1",
+    "@algolia/recommend-core": "1.3.0",
+    "@algolia/recommend-vdom": "1.3.0",
     "preact": "^10.0.0"
   }
 }

--- a/packages/recommend-js/src/version.ts
+++ b/packages/recommend-js/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '1.3.1';
+export const version = '1.3.0';

--- a/packages/recommend-react/package.json
+++ b/packages/recommend-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@algolia/recommend-react",
   "description": "Horizontal slider UI component.",
-  "version": "1.3.1",
+  "version": "1.3.0",
   "license": "MIT",
   "homepage": "https://github.com/algolia/recommend",
   "repository": "algolia/recommend",
@@ -29,8 +29,8 @@
     "prepare": "yarn build:esm && yarn build:types"
   },
   "dependencies": {
-    "@algolia/recommend-core": "1.3.1",
-    "@algolia/recommend-vdom": "1.3.1",
+    "@algolia/recommend-core": "1.3.0",
+    "@algolia/recommend-vdom": "1.3.0",
     "dequal": "^2.0.0"
   },
   "peerDependencies": {

--- a/packages/recommend-react/src/version.ts
+++ b/packages/recommend-react/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '1.3.1';
+export const version = '1.3.0';

--- a/packages/recommend-vdom/package.json
+++ b/packages/recommend-vdom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/recommend-vdom",
-  "version": "1.3.1",
+  "version": "1.3.0",
   "license": "MIT",
   "homepage": "https://github.com/algolia/recommend",
   "repository": "algolia/recommend",
@@ -28,6 +28,6 @@
     "prepare": "yarn build:esm && yarn build:types"
   },
   "devDependencies": {
-    "@algolia/recommend-core": "1.3.1"
+    "@algolia/recommend-core": "1.3.0"
   }
 }

--- a/packages/recommend-vdom/src/version.ts
+++ b/packages/recommend-vdom/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '1.3.1';
+export const version = '1.3.0';


### PR DESCRIPTION
This reverts commit 1c6dd14d34a7680957f860fbb987605b3b1fbef1. 
As this commit can't be released, we are trying to remove and reopen it differently. A new `chore` PR will be opened. 