### PR TITLE
fix(html-template): use htm/preact

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -6,7 +6,7 @@
     },
     {
       "path": "packages/recommend-js/dist/umd/index.js",
-      "maxSize": "7.35 kB"
+      "maxSize": "8.25 kB"
     },
     {
       "path": "packages/recommend-react/dist/umd/index.js",

--- a/packages/recommend-js/src/frequentlyBoughtTogether.tsx
+++ b/packages/recommend-js/src/frequentlyBoughtTogether.tsx
@@ -8,11 +8,12 @@ import {
   createFrequentlyBoughtTogetherComponent,
   FrequentlyBoughtTogetherProps as FrequentlyBoughtTogetherVDOMProps,
 } from '@algolia/recommend-vdom';
+import { html } from 'htm/preact';
 import { createElement, Fragment, h, render } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 
 import { getHTMLElement } from './getHTMLElement';
-import { EnvironmentProps, html, Template } from './types';
+import { EnvironmentProps, Template } from './types';
 import { useAlgoliaAgent } from './useAlgoliaAgent';
 import { useStatus } from './useStatus';
 
@@ -83,7 +84,7 @@ export function frequentlyBoughtTogether<TObject>({
   children,
   ...props
 }: FrequentlyBoughtTogetherProps<TObject, Template> & EnvironmentProps) {
-  const component = (
+  const vnode = (
     <FrequentlyBoughtTogether<TObject, Template>
       {...props}
       view={view ? (viewProps) => view({ ...viewProps, html }) : undefined}
@@ -111,10 +112,10 @@ export function frequentlyBoughtTogether<TObject>({
   );
 
   if (!container) {
-    return component;
+    return vnode;
   }
 
-  render(component, getHTMLElement(container, environment));
+  render(vnode, getHTMLElement(container, environment));
 
   return null;
 }

--- a/packages/recommend-js/src/relatedProducts.tsx
+++ b/packages/recommend-js/src/relatedProducts.tsx
@@ -8,11 +8,12 @@ import {
   createRelatedProductsComponent,
   RelatedProductsProps as RelatedProductsVDOMProps,
 } from '@algolia/recommend-vdom';
+import { html } from 'htm/preact';
 import { createElement, Fragment, h, render } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 
 import { getHTMLElement } from './getHTMLElement';
-import { EnvironmentProps, Template, html } from './types';
+import { EnvironmentProps, Template } from './types';
 import { useAlgoliaAgent } from './useAlgoliaAgent';
 import { useStatus } from './useStatus';
 
@@ -74,7 +75,7 @@ export function relatedProducts<TObject>({
   children,
   ...props
 }: RelatedProductsProps<TObject, Template> & EnvironmentProps) {
-  const component = (
+  const vnode = (
     <RelatedProducts<TObject, Template>
       {...props}
       view={view ? (viewProps) => view({ ...viewProps, html }) : undefined}
@@ -102,10 +103,10 @@ export function relatedProducts<TObject>({
   );
 
   if (!container) {
-    return component;
+    return vnode;
   }
 
-  render(component, getHTMLElement(container, environment));
+  render(vnode, getHTMLElement(container, environment));
 
   return null;
 }

--- a/packages/recommend-js/src/trendingFacets.tsx
+++ b/packages/recommend-js/src/trendingFacets.tsx
@@ -8,11 +8,12 @@ import {
   createTrendingFacetsComponent,
   TrendingComponentProps as TrendingFacetsVDOMProps,
 } from '@algolia/recommend-vdom';
+import { html } from 'htm/preact';
 import { createElement, Fragment, h, render } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 
 import { getHTMLElement } from './getHTMLElement';
-import { EnvironmentProps, html, Template } from './types';
+import { EnvironmentProps, Template } from './types';
 import { useAlgoliaAgent } from './useAlgoliaAgent';
 import { useStatus } from './useStatus';
 
@@ -73,10 +74,10 @@ export function trendingFacets<TObject>({
   children,
   ...props
 }: TrendingFacetsProps<TObject, Template> & EnvironmentProps) {
-  const component = (
+  const vnode = (
     <TrendingFacets<TObject, Template>
       {...props}
-      view={view ? (viewProps) => view({ ...viewProps, html }) : undefined}
+      view={view && ((viewProps) => view({ ...viewProps, html }))}
       itemComponent={(itemComponentProps) =>
         itemComponent({
           ...itemComponentProps,
@@ -101,10 +102,10 @@ export function trendingFacets<TObject>({
   );
 
   if (!container) {
-    return component;
+    return vnode;
   }
 
-  render(component, getHTMLElement(container, environment));
+  render(vnode, getHTMLElement(container, environment));
 
   return null;
 }

--- a/packages/recommend-js/src/trendingItems.tsx
+++ b/packages/recommend-js/src/trendingItems.tsx
@@ -8,11 +8,12 @@ import {
   createTrendingItemsComponent,
   TrendingItemsProps as TrendingItemsVDOMProps,
 } from '@algolia/recommend-vdom';
+import { html } from 'htm/preact';
 import { createElement, Fragment, h, render } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 
 import { getHTMLElement } from './getHTMLElement';
-import { EnvironmentProps, Template, html } from './types';
+import { EnvironmentProps, Template } from './types';
 import { useAlgoliaAgent } from './useAlgoliaAgent';
 import { useStatus } from './useStatus';
 
@@ -73,7 +74,7 @@ export function trendingItems<TObject>({
   children,
   ...props
 }: TrendingItemsProps<TObject, Template> & EnvironmentProps) {
-  const component = (
+  const vnode = (
     <TrendingItems<TObject, Template>
       {...props}
       view={view ? (viewProps) => view({ ...viewProps, html }) : undefined}
@@ -101,10 +102,10 @@ export function trendingItems<TObject>({
   );
 
   if (!container) {
-    return component;
+    return vnode;
   }
 
-  render(component, getHTMLElement(container, environment));
+  render(vnode, getHTMLElement(container, environment));
 
   return null;
 }

--- a/packages/recommend-js/src/types/HTMLTemplate.tsx
+++ b/packages/recommend-js/src/types/HTMLTemplate.tsx
@@ -1,10 +1,5 @@
-import { VNode } from '@algolia/recommend-vdom';
-
-export type HTMLTemplate = (
-  strings: TemplateStringsArray,
-  ...values: any[]
-) => VNode | VNode[];
+import { html } from 'htm/preact';
 
 export type Template = {
-  html: HTMLTemplate;
+  html: typeof html;
 };

--- a/packages/recommend-js/src/types/html.tsx
+++ b/packages/recommend-js/src/types/html.tsx
@@ -1,5 +1,0 @@
-import { VNode } from '@algolia/recommend-vdom';
-import htm from 'htm';
-import { createElement } from 'preact';
-
-export const html = htm.bind<VNode>(createElement);

--- a/packages/recommend-js/src/types/index.ts
+++ b/packages/recommend-js/src/types/index.ts
@@ -1,3 +1,2 @@
 export * from './EnvironmentProps';
 export * from './HTMLTemplate';
-export * from './html';

--- a/packages/recommend-vdom/src/FacetsView.tsx
+++ b/packages/recommend-vdom/src/FacetsView.tsx
@@ -23,11 +23,11 @@ export function createFacetsView({ createElement, Fragment }: Renderer) {
               key={item.facetValue}
               className={cx('auc-Recommend-item', props.classNames.item)}
             >
-              {props.itemComponent({
-                createElement,
-                Fragment,
-                item,
-              })}
+              <props.itemComponent
+                createElement={createElement}
+                Fragment={Fragment}
+                item={item}
+              />
             </li>
           ))}
         </ol>

--- a/packages/recommend-vdom/src/FrequentlyBoughtTogether.tsx
+++ b/packages/recommend-vdom/src/FrequentlyBoughtTogether.tsx
@@ -30,54 +30,36 @@ export function createFrequentlyBoughtTogetherComponent({
     const children =
       props.children ??
       createDefaultChildrenComponent({ createElement, Fragment });
-    const fallbackComponent =
+    const FallbackComponent =
       props.fallbackComponent ?? createDefaultFallbackComponent();
     const Fallback = () => (
-      <Fragment>{fallbackComponent({ createElement, Fragment })}</Fragment>
+      <FallbackComponent Fragment={Fragment} createElement={createElement} />
     );
-    const headerComponent =
+    const Header =
       props.headerComponent ??
       createDefaultHeaderComponent({ createElement, Fragment });
-    const Header = () => (
-      <Fragment>
-        {headerComponent({
-          classNames,
-          recommendations: props.items,
-          translations,
-          createElement,
-          Fragment,
-        })}
-      </Fragment>
-    );
-    const viewComponent =
+    const ViewComponent =
       props.view ?? createListViewComponent({ createElement, Fragment });
     const View = (viewProps: unknown) => (
-      <Fragment>
-        {viewComponent({
-          classNames,
-          itemComponent: props.itemComponent,
-          items: props.items,
-          translations,
-          Fragment,
-          createElement,
-          // @ts-ignore
-          ...viewProps,
-        })}
-      </Fragment>
+      <ViewComponent
+        classNames={classNames}
+        itemComponent={props.itemComponent}
+        items={props.items}
+        translations={translations}
+        Fragment={Fragment}
+        createElement={createElement}
+        {...viewProps}
+      />
     );
 
-    return (
-      <Fragment>
-        {children({
-          classNames,
-          Fallback,
-          Header,
-          recommendations: props.items,
-          status: props.status,
-          translations,
-          View,
-        })}
-      </Fragment>
-    );
+    return children({
+      classNames,
+      Fallback,
+      Header,
+      recommendations: props.items,
+      status: props.status,
+      translations,
+      View,
+    });
   };
 }

--- a/packages/recommend-vdom/src/ListView.tsx
+++ b/packages/recommend-vdom/src/ListView.tsx
@@ -23,7 +23,11 @@ export function createListViewComponent({ createElement, Fragment }: Renderer) {
               key={item.objectID}
               className={cx('auc-Recommend-item', props.classNames.item)}
             >
-              {props.itemComponent({ createElement, Fragment, item })}
+              <props.itemComponent
+                createElement={createElement}
+                Fragment={Fragment}
+                item={item}
+              />
             </li>
           ))}
         </ol>

--- a/packages/recommend-vdom/src/RelatedProducts.tsx
+++ b/packages/recommend-vdom/src/RelatedProducts.tsx
@@ -31,54 +31,36 @@ export function createRelatedProductsComponent({
     const children =
       props.children ??
       createDefaultChildrenComponent({ createElement, Fragment });
-    const fallbackComponent =
+    const FallbackComponent =
       props.fallbackComponent ?? createDefaultFallbackComponent();
     const Fallback = () => (
-      <Fragment>{fallbackComponent({ createElement, Fragment })}</Fragment>
+      <FallbackComponent Fragment={Fragment} createElement={createElement} />
     );
-    const headerComponent =
+    const Header =
       props.headerComponent ??
       createDefaultHeaderComponent({ createElement, Fragment });
-    const Header = () => (
-      <Fragment>
-        {headerComponent({
-          classNames,
-          recommendations: props.items,
-          translations,
-          createElement,
-          Fragment,
-        })}
-      </Fragment>
-    );
-    const viewComponent =
+    const ViewComponent =
       props.view ?? createListViewComponent({ createElement, Fragment });
     const View = (viewProps: unknown) => (
-      <Fragment>
-        {viewComponent({
-          classNames,
-          itemComponent: props.itemComponent,
-          items: props.items,
-          translations,
-          Fragment,
-          createElement,
-          // @ts-ignore
-          ...viewProps,
-        })}
-      </Fragment>
+      <ViewComponent
+        classNames={classNames}
+        itemComponent={props.itemComponent}
+        items={props.items}
+        translations={translations}
+        Fragment={Fragment}
+        createElement={createElement}
+        {...viewProps}
+      />
     );
 
-    return (
-      <Fragment>
-        {children({
-          classNames,
-          Fallback,
-          Header,
-          recommendations: props.items,
-          status: props.status,
-          translations,
-          View,
-        })}
-      </Fragment>
-    );
+    return children({
+      classNames,
+      Fallback,
+      Header,
+      recommendations: props.items,
+      status: props.status,
+      translations,
+      View,
+    });
   };
 }

--- a/packages/recommend-vdom/src/TrendingFacets.tsx
+++ b/packages/recommend-vdom/src/TrendingFacets.tsx
@@ -26,54 +26,36 @@ export function createTrendingFacetsComponent({
     const children =
       props.children ??
       createDefaultChildrenComponent({ createElement, Fragment });
-    const fallbackComponent =
+    const FallbackComponent =
       props.fallbackComponent ?? createDefaultFallbackComponent();
     const Fallback = () => (
-      <Fragment>{fallbackComponent({ createElement, Fragment })}</Fragment>
+      <FallbackComponent Fragment={Fragment} createElement={createElement} />
     );
-    const headerComponent =
+    const Header =
       props.headerComponent ??
       createDefaultHeaderComponent({ createElement, Fragment });
-    const Header = () => (
-      <Fragment>
-        {headerComponent({
-          classNames,
-          recommendations: props.items,
-          translations,
-          createElement,
-          Fragment,
-        })}
-      </Fragment>
-    );
-    const viewComponent =
+    const ViewComponent =
       props.view ?? createFacetsView({ createElement, Fragment });
     const View = (viewProps: unknown) => (
-      <Fragment>
-        {viewComponent({
-          classNames,
-          itemComponent: props.itemComponent,
-          items: props.items,
-          translations,
-          Fragment,
-          createElement,
-          // @ts-ignore
-          ...viewProps,
-        })}
-      </Fragment>
+      <ViewComponent
+        classNames={classNames}
+        itemComponent={props.itemComponent}
+        items={props.items}
+        translations={translations}
+        Fragment={Fragment}
+        createElement={createElement}
+        {...viewProps}
+      />
     );
 
-    return (
-      <Fragment>
-        {children({
-          classNames,
-          Fallback,
-          Header,
-          recommendations: props.items,
-          status: props.status,
-          translations,
-          View,
-        })}
-      </Fragment>
-    );
+    return children({
+      classNames,
+      Fallback,
+      Header,
+      recommendations: props.items,
+      status: props.status,
+      translations,
+      View,
+    });
   };
 }

--- a/packages/recommend-vdom/src/TrendingItems.tsx
+++ b/packages/recommend-vdom/src/TrendingItems.tsx
@@ -29,54 +29,36 @@ export function createTrendingItemsComponent({
     const children =
       props.children ??
       createDefaultChildrenComponent({ createElement, Fragment });
-    const fallbackComponent =
+    const FallbackComponent =
       props.fallbackComponent ?? createDefaultFallbackComponent();
     const Fallback = () => (
-      <Fragment>{fallbackComponent({ createElement, Fragment })}</Fragment>
+      <FallbackComponent Fragment={Fragment} createElement={createElement} />
     );
-    const headerComponent =
+    const Header =
       props.headerComponent ??
       createDefaultHeaderComponent({ createElement, Fragment });
-    const Header = () => (
-      <Fragment>
-        {headerComponent({
-          classNames,
-          recommendations: props.items,
-          translations,
-          createElement,
-          Fragment,
-        })}
-      </Fragment>
-    );
-    const viewComponent =
+    const ViewComponent =
       props.view ?? createListViewComponent({ createElement, Fragment });
     const View = (viewProps: unknown) => (
-      <Fragment>
-        {viewComponent({
-          classNames,
-          itemComponent: props.itemComponent,
-          items: props.items,
-          translations,
-          Fragment,
-          createElement,
-          // @ts-ignore
-          ...viewProps,
-        })}
-      </Fragment>
+      <ViewComponent
+        classNames={classNames}
+        itemComponent={props.itemComponent}
+        items={props.items}
+        translations={translations}
+        Fragment={Fragment}
+        createElement={createElement}
+        {...viewProps}
+      />
     );
 
-    return (
-      <Fragment>
-        {children({
-          classNames,
-          Fallback,
-          Header,
-          recommendations: props.items,
-          status: props.status,
-          translations,
-          View,
-        })}
-      </Fragment>
-    );
+    return children({
+      classNames,
+      Fallback,
+      Header,
+      recommendations: props.items,
+      status: props.status,
+      translations,
+      View,
+    });
   };
 }

--- a/packages/recommend-vdom/src/types/FacetsViewProps.ts
+++ b/packages/recommend-vdom/src/types/FacetsViewProps.ts
@@ -1,6 +1,6 @@
 import { FacetEntry } from '@algolia/recommend-core';
 
-import { Renderer, VNode } from './Renderer';
+import { Renderer } from './Renderer';
 
 export type FacetsViewProps<
   TItem extends FacetEntry,
@@ -10,7 +10,7 @@ export type FacetsViewProps<
   classNames: TClassNames;
   itemComponent<TComponentProps extends Record<string, unknown> = {}>(
     props: { item: TItem } & Renderer & TComponentProps
-  ): VNode | VNode[];
+  ): JSX.Element;
   items: TItem[];
   translations: TTranslations;
 };

--- a/packages/recommend-vdom/src/types/RecommendComponentProps.ts
+++ b/packages/recommend-vdom/src/types/RecommendComponentProps.ts
@@ -4,7 +4,7 @@ import { FacetsViewProps } from './FacetsViewProps';
 import { RecommendClassNames } from './RecommendClassNames';
 import { RecommendStatus } from './RecommendStatus';
 import { RecommendTranslations } from './RecommendTranslations';
-import { Renderer, VNode } from './Renderer';
+import { Renderer } from './Renderer';
 import { ViewProps } from './ViewProps';
 
 export type ItemComponentProps<TObject> = {
@@ -20,10 +20,10 @@ export type ComponentProps<TObject> = {
 };
 
 export type ChildrenProps<TObject> = ComponentProps<TObject> & {
-  Fallback(): VNode | null;
-  Header(props: HeaderComponentProps<TObject>): VNode | null;
+  Fallback(): JSX.Element | null;
+  Header(props: HeaderComponentProps<TObject>): JSX.Element | null;
   status: RecommendStatus;
-  View(props: unknown): VNode | null;
+  View(props: unknown): JSX.Element;
 };
 
 export type RecommendComponentProps<
@@ -32,16 +32,14 @@ export type RecommendComponentProps<
 > = {
   itemComponent(
     props: ItemComponentProps<RecordWithObjectID<TObject>> & TComponentProps
-  ): VNode | VNode[];
+  ): JSX.Element;
   items: Array<RecordWithObjectID<TObject>>;
   classNames?: RecommendClassNames;
-  children?(
-    props: ChildrenProps<TObject> & TComponentProps
-  ): VNode | VNode[] | null;
-  fallbackComponent?(props: Renderer & TComponentProps): VNode | VNode[] | null;
+  children?(props: ChildrenProps<TObject> & TComponentProps): JSX.Element;
+  fallbackComponent?(props: Renderer & TComponentProps): JSX.Element;
   headerComponent?(
     props: HeaderComponentProps<TObject> & TComponentProps
-  ): VNode | VNode[] | null;
+  ): JSX.Element;
   status: RecommendStatus;
   translations?: RecommendTranslations;
   view?(
@@ -52,7 +50,7 @@ export type RecommendComponentProps<
     > &
       Renderer &
       TComponentProps
-  ): VNode | VNode[] | null;
+  ): JSX.Element;
 };
 
 export type TrendingComponentProps<
@@ -61,14 +59,14 @@ export type TrendingComponentProps<
 > = {
   itemComponent(
     props: ItemComponentProps<FacetEntry<TObject>> & TComponentProps
-  ): VNode | VNode[];
+  ): JSX.Element;
   items: Array<FacetEntry<TObject>>;
   classNames?: RecommendClassNames;
-  children?(props: ChildrenProps<TObject> & TComponentProps): VNode;
-  fallbackComponent?(props: Renderer & TComponentProps): VNode | VNode[] | null;
+  children?(props: ChildrenProps<TObject> & TComponentProps): JSX.Element;
+  fallbackComponent?(props: Renderer & TComponentProps): JSX.Element;
   headerComponent?(
     props: HeaderComponentProps<TObject> & TComponentProps
-  ): VNode | VNode[] | null;
+  ): JSX.Element;
   status: RecommendStatus;
   translations?: RecommendTranslations;
   view?(
@@ -79,5 +77,5 @@ export type TrendingComponentProps<
     > &
       Renderer &
       TComponentProps
-  ): VNode | VNode[] | null;
+  ): JSX.Element;
 };

--- a/packages/recommend-vdom/src/types/ViewProps.ts
+++ b/packages/recommend-vdom/src/types/ViewProps.ts
@@ -1,6 +1,6 @@
 import { RecordWithObjectID } from '@algolia/recommend-core';
 
-import { Renderer, VNode } from './Renderer';
+import { Renderer } from './Renderer';
 
 export type ViewProps<
   TItem extends RecordWithObjectID,
@@ -10,7 +10,7 @@ export type ViewProps<
   classNames: TClassNames;
   itemComponent<TComponentProps extends Record<string, unknown> = {}>(
     props: { item: TItem } & Renderer & TComponentProps
-  ): VNode;
+  ): JSX.Element;
   items: TItem[];
   translations: TTranslations;
 };


### PR DESCRIPTION
Here are a few fixes : 
- Replaces manual `htm` binding with `htm/preact` integration which fixes the type issues and allows to revert to previous types
- Renamed `component` to `vnode` in `recommend-js` because it's the name of the argument in `render`
- Adjusted bundlesize to `8.25kb` to account for `htm`