### PR TITLE
feat(react): export props types

### DIFF
--- a/packages/recommend-react/src/FrequentlyBoughtTogether.tsx
+++ b/packages/recommend-react/src/FrequentlyBoughtTogether.tsx
@@ -14,7 +14,7 @@ const UncontrolledFrequentlyBoughtTogether = createFrequentlyBoughtTogetherCompo
   }
 );
 
-type FrequentlyBoughtTogetherProps<
+export type FrequentlyBoughtTogetherProps<
   TObject
 > = GetFrequentlyBoughtTogetherProps<TObject> &
   Omit<FrequentlyBoughtTogetherVDOMProps<TObject>, 'items' | 'status'>;

--- a/packages/recommend-react/src/RelatedProducts.tsx
+++ b/packages/recommend-react/src/RelatedProducts.tsx
@@ -12,7 +12,7 @@ const UncontrolledRelatedProducts = createRelatedProductsComponent({
   Fragment,
 });
 
-type RelatedProductsProps<TObject> = GetRelatedProductsProps<TObject> &
+export type RelatedProductsProps<TObject> = GetRelatedProductsProps<TObject> &
   Omit<RelatedProductsVDOMProps<TObject>, 'items' | 'status'>;
 
 export function RelatedProducts<TObject>(props: RelatedProductsProps<TObject>) {

--- a/packages/recommend-react/src/TrendingFacets.tsx
+++ b/packages/recommend-react/src/TrendingFacets.tsx
@@ -12,7 +12,7 @@ const UncontrolledTrendingFacets = createTrendingFacetsComponent({
   Fragment,
 });
 
-type TrendingFacetsProps<TObject> = GetTrendingFacetsProps<TObject> &
+export type TrendingFacetsProps<TObject> = GetTrendingFacetsProps<TObject> &
   Omit<TrendingFacetsVDOMProps<TObject>, 'items' | 'status'>;
 
 export function TrendingFacets<TObject>(props: TrendingFacetsProps<TObject>) {

--- a/packages/recommend-react/src/TrendingItems.tsx
+++ b/packages/recommend-react/src/TrendingItems.tsx
@@ -12,7 +12,7 @@ const UncontrolledTrendingItems = createTrendingItemsComponent({
   Fragment,
 });
 
-type TrendingItemsProps<TObject> = GetTrendingItemsProps<TObject> &
+export type TrendingItemsProps<TObject> = GetTrendingItemsProps<TObject> &
   Omit<TrendingItemsVDOMProps<TObject>, 'items' | 'status'>;
 
 export function TrendingItems<TObject>(props: TrendingItemsProps<TObject>) {

--- a/packages/recommend-react/src/useFrequentlyBoughtTogether.ts
+++ b/packages/recommend-react/src/useFrequentlyBoughtTogether.ts
@@ -9,6 +9,10 @@ import { useAlgoliaAgent } from './useAlgoliaAgent';
 import { useStableValue } from './useStableValue';
 import { useStatus } from './useStatus';
 
+export type UseFrequentlyBoughtTogetherProps<
+  TObject
+> = GetFrequentlyBoughtTogetherProps<TObject>;
+
 export function useFrequentlyBoughtTogether<TObject>({
   indexName,
   maxRecommendations,
@@ -17,7 +21,7 @@ export function useFrequentlyBoughtTogether<TObject>({
   recommendClient,
   threshold,
   transformItems: userTransformItems,
-}: GetFrequentlyBoughtTogetherProps<TObject>) {
+}: UseFrequentlyBoughtTogetherProps<TObject>) {
   const [result, setResult] = useState<GetRecommendationsResult<TObject>>({
     recommendations: [],
   });

--- a/packages/recommend-react/src/useRecommendations.ts
+++ b/packages/recommend-react/src/useRecommendations.ts
@@ -9,6 +9,8 @@ import { useAlgoliaAgent } from './useAlgoliaAgent';
 import { useStableValue } from './useStableValue';
 import { useStatus } from './useStatus';
 
+export type UseRecommendationsProps<TObject> = GetRecommendationsProps<TObject>;
+
 export function useRecommendations<TObject>({
   fallbackParameters: userFallbackParameters,
   indexName,
@@ -19,7 +21,7 @@ export function useRecommendations<TObject>({
   recommendClient,
   threshold,
   transformItems: userTransformItems,
-}: GetRecommendationsProps<TObject>) {
+}: UseRecommendationsProps<TObject>) {
   const [result, setResult] = useState<GetRecommendationsResult<TObject>>({
     recommendations: [],
   });

--- a/packages/recommend-react/src/useRelatedProducts.ts
+++ b/packages/recommend-react/src/useRelatedProducts.ts
@@ -9,6 +9,8 @@ import { useAlgoliaAgent } from './useAlgoliaAgent';
 import { useStableValue } from './useStableValue';
 import { useStatus } from './useStatus';
 
+export type UseRelatedProductsProps<TObject> = GetRelatedProductsProps<TObject>;
+
 export function useRelatedProducts<TObject>({
   fallbackParameters: userFallbackParameters,
   indexName,
@@ -18,7 +20,7 @@ export function useRelatedProducts<TObject>({
   recommendClient,
   threshold,
   transformItems: userTransformItems,
-}: GetRelatedProductsProps<TObject>) {
+}: UseRelatedProductsProps<TObject>) {
   const [result, setResult] = useState<GetRecommendationsResult<TObject>>({
     recommendations: [],
   });

--- a/packages/recommend-react/src/useTrendingFacets.ts
+++ b/packages/recommend-react/src/useTrendingFacets.ts
@@ -9,6 +9,8 @@ import { useAlgoliaAgent } from './useAlgoliaAgent';
 import { useStableValue } from './useStableValue';
 import { useStatus } from './useStatus';
 
+export type UseTrendingFacetsProps<TObject> = GetTrendingFacetsProps<TObject>;
+
 export function useTrendingFacets<TObject>({
   fallbackParameters: userFallbackParameters,
   indexName,
@@ -18,7 +20,7 @@ export function useTrendingFacets<TObject>({
   threshold,
   transformItems: userTransformItems,
   facetName,
-}: GetTrendingFacetsProps<TObject>) {
+}: UseTrendingFacetsProps<TObject>) {
   const [result, setResult] = useState<GetTrendingFacetsResult<TObject>>({
     recommendations: [],
   });

--- a/packages/recommend-react/src/useTrendingItems.ts
+++ b/packages/recommend-react/src/useTrendingItems.ts
@@ -9,6 +9,8 @@ import { useAlgoliaAgent } from './useAlgoliaAgent';
 import { useStableValue } from './useStableValue';
 import { useStatus } from './useStatus';
 
+export type UseTrendingItemsProps<TObject> = GetTrendingItemsProps<TObject>;
+
 export function useTrendingItems<TObject>({
   fallbackParameters: userFallbackParameters,
   indexName,
@@ -19,7 +21,7 @@ export function useTrendingItems<TObject>({
   transformItems: userTransformItems,
   facetName,
   facetValue,
-}: GetTrendingItemsProps<TObject>) {
+}: UseTrendingItemsProps<TObject>) {
   const [result, setResult] = useState<GetTrendingItemsResult<TObject>>({
     recommendations: [],
   });


### PR DESCRIPTION
The components and Hooks props were not exported so it wasn't simple to re-create higher-level components reusing these props.

In the other libraries, we make sure to export the types that are close to the developer usage.