### PR TITLE
chore: Fix verbose output in react-hook tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,15 @@
 module.exports = {
   clearMocks: true,
-
   testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/test/setup.js'],
   transformIgnorePatterns: ['node_modules/(?!preact)/'],
   // Remove "snapshotFormat" and update to new format once initial PR is merged
   snapshotFormat: {
     escapeString: true,
     printBasicPrototype: true,
   },
+  watchPlugins: [
+    'jest-watch-typeahead/filename',
+    'jest-watch-typeahead/testname',
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
     "https-browserify": "^1.0.0",
     "jest": "29.4.3",
     "jest-environment-jsdom": "^29.4.3",
+    "jest-fail-on-console": "^3.0.2",
+    "jest-watch-typeahead": "^2.2.2",
     "lerna": "6.5.1",
     "prettier": "2.2.1",
     "process": "^0.11.10",

--- a/packages/recommend-js/src/__tests__/trendingFacets.test.tsx
+++ b/packages/recommend-js/src/__tests__/trendingFacets.test.tsx
@@ -93,6 +93,7 @@ describe('trendingFacets', () => {
       document.body.appendChild(container);
 
       trendingFacets<ObjectWithObjectID>({
+        facetName: 'facet-name',
         container,
         recommendClient,
         indexName: 'products',
@@ -149,6 +150,7 @@ describe('trendingFacets', () => {
       document.body.appendChild(container);
 
       trendingFacets<ObjectWithObjectID>({
+        facetName: 'facet-name',
         container,
         recommendClient,
         indexName: 'products',
@@ -203,6 +205,7 @@ describe('trendingFacets', () => {
       document.body.appendChild(container);
 
       trendingFacets<ObjectWithObjectID>({
+        facetName: 'facet-name',
         container,
         recommendClient,
         indexName: 'products',
@@ -263,6 +266,7 @@ describe('trendingFacets', () => {
       document.body.appendChild(container);
 
       trendingFacets<ObjectWithObjectID>({
+        facetName: 'facet-name',
         container,
         recommendClient,
         indexName: 'products',
@@ -288,6 +292,7 @@ describe('trendingFacets', () => {
       document.body.appendChild(container);
 
       trendingFacets<ObjectWithObjectID>({
+        facetName: 'facet-name',
         container,
         recommendClient,
         indexName: 'products',
@@ -315,6 +320,7 @@ describe('trendingFacets', () => {
       document.body.appendChild(container);
 
       trendingFacets<ObjectWithObjectID>({
+        facetName: 'facet-name',
         container,
         recommendClient,
         indexName: 'products',
@@ -452,6 +458,7 @@ describe('trendingFacets', () => {
       document.body.appendChild(container);
 
       trendingFacets<ObjectWithObjectID>({
+        facetName: 'facet-name',
         container,
         recommendClient,
         indexName: 'products',

--- a/packages/recommend-react/src/__tests__/useFrequentlyBoughtTogether.test.ts
+++ b/packages/recommend-react/src/__tests__/useFrequentlyBoughtTogether.test.ts
@@ -30,7 +30,7 @@ describe('useFrequentlyBoughtTogether', () => {
   test('returns FBT recommendations', async () => {
     const { recommendClient } = createMockedRecommendClient();
 
-    const { result } = renderHook(() =>
+    const { result, waitForNextUpdate } = renderHook(() =>
       useFrequentlyBoughtTogether({
         indexName: 'test',
         recommendClient,
@@ -41,6 +41,7 @@ describe('useFrequentlyBoughtTogether', () => {
         },
       })
     );
+    await waitForNextUpdate();
     await waitFor(() => {
       expect(result.current.recommendations).toEqual([hit]);
     });
@@ -49,7 +50,7 @@ describe('useFrequentlyBoughtTogether', () => {
   test('assures that the transformItems function is applied properly after rerender', async () => {
     const { recommendClient } = createMockedRecommendClient();
 
-    const { result, rerender } = renderHook(
+    const { result, rerender, waitForNextUpdate } = renderHook(
       ({ transformItems, indexName }) =>
         useFrequentlyBoughtTogether({
           indexName,
@@ -69,6 +70,7 @@ describe('useFrequentlyBoughtTogether', () => {
         },
       }
     );
+    await waitForNextUpdate();
     await waitFor(() => {
       expect(result.current.recommendations).toEqual([
         'Landoh 4-Pocket Jumpsuit',
@@ -79,6 +81,7 @@ describe('useFrequentlyBoughtTogether', () => {
       rerender({ transformItems: getItemPrice, indexName: 'test1' });
     });
 
+    await waitForNextUpdate();
     await waitFor(() => {
       expect(result.current.recommendations).toEqual([250]);
     });

--- a/packages/recommend-react/src/__tests__/useRecommendations.test.ts
+++ b/packages/recommend-react/src/__tests__/useRecommendations.test.ts
@@ -30,7 +30,7 @@ describe('useRecommendations', () => {
   test('gets recommendations', async () => {
     const { recommendClient } = createMockedRecommendClient();
 
-    const { result } = renderHook(() =>
+    const { result, waitForNextUpdate } = renderHook(() =>
       useRecommendations({
         model: 'bought-together',
         indexName: 'test',
@@ -46,6 +46,7 @@ describe('useRecommendations', () => {
       })
     );
 
+    await waitForNextUpdate();
     await waitFor(() => {
       expect(result.current.recommendations).toEqual([hit]);
     });
@@ -54,7 +55,7 @@ describe('useRecommendations', () => {
   test('assures that the transformItems function is applied properly after rerender', async () => {
     const { recommendClient } = createMockedRecommendClient();
 
-    const { result, rerender } = renderHook(
+    const { result, rerender, waitForNextUpdate } = renderHook(
       ({ transformItems, indexName }) =>
         useRecommendations({
           indexName,
@@ -75,6 +76,7 @@ describe('useRecommendations', () => {
         },
       }
     );
+    await waitForNextUpdate();
     await waitFor(() => {
       expect(result.current.recommendations).toEqual([
         'Landoh 4-Pocket Jumpsuit',
@@ -85,6 +87,7 @@ describe('useRecommendations', () => {
       rerender({ transformItems: getItemPrice, indexName: 'test1' });
     });
 
+    await waitForNextUpdate();
     await waitFor(() => {
       expect(result.current.recommendations).toEqual([250]);
     });

--- a/packages/recommend-react/src/__tests__/useRelatedProducts.test.ts
+++ b/packages/recommend-react/src/__tests__/useRelatedProducts.test.ts
@@ -30,7 +30,7 @@ describe('useRelatedProducts', () => {
   test('gets Related Products', async () => {
     const { recommendClient } = createMockedRecommendClient();
 
-    const { result } = renderHook(() =>
+    const { result, waitForNextUpdate } = renderHook(() =>
       useRelatedProducts({
         indexName: 'test',
         recommendClient,
@@ -45,6 +45,7 @@ describe('useRelatedProducts', () => {
       })
     );
 
+    await waitForNextUpdate();
     await waitFor(() => {
       expect(result.current.recommendations).toEqual([hit]);
     });
@@ -53,7 +54,7 @@ describe('useRelatedProducts', () => {
   test('assures that the transformItems function is applied properly after rerender', async () => {
     const { recommendClient } = createMockedRecommendClient();
 
-    const { result, rerender } = renderHook(
+    const { result, rerender, waitForNextUpdate } = renderHook(
       ({ transformItems, indexName }) =>
         useRelatedProducts({
           indexName,
@@ -73,6 +74,8 @@ describe('useRelatedProducts', () => {
         },
       }
     );
+
+    await waitForNextUpdate();
     await waitFor(() => {
       expect(result.current.recommendations).toEqual([
         'Landoh 4-Pocket Jumpsuit',
@@ -83,6 +86,7 @@ describe('useRelatedProducts', () => {
       rerender({ transformItems: getItemPrice, indexName: 'test1' });
     });
 
+    await waitForNextUpdate();
     await waitFor(() => {
       expect(result.current.recommendations).toEqual([250]);
     });

--- a/packages/recommend-react/src/__tests__/useTrendingFacets.test.ts
+++ b/packages/recommend-react/src/__tests__/useTrendingFacets.test.ts
@@ -30,7 +30,7 @@ describe('useTrendingFacets', () => {
   test('gets trending facets', async () => {
     const { recommendClient } = createMockedRecommendClient();
 
-    const { result } = renderHook(() =>
+    const { result, waitForNextUpdate } = renderHook(() =>
       useTrendingFacets({
         indexName: 'test',
         recommendClient,
@@ -39,6 +39,7 @@ describe('useTrendingFacets', () => {
       })
     );
 
+    await waitForNextUpdate();
     await waitFor(() => {
       expect(result.current.recommendations).toEqual([hit]);
     });
@@ -47,7 +48,7 @@ describe('useTrendingFacets', () => {
   test('assures that the transformItems function is applied properly after rerender', async () => {
     const { recommendClient } = createMockedRecommendClient();
 
-    const { result, rerender } = renderHook(
+    const { result, rerender, waitForNextUpdate } = renderHook(
       ({ transformItems, indexName }) =>
         useTrendingFacets({
           indexName,
@@ -64,6 +65,8 @@ describe('useTrendingFacets', () => {
         },
       }
     );
+
+    await waitForNextUpdate();
     await waitFor(() => {
       expect(result.current.recommendations).toEqual([
         'Landoh 4-Pocket Jumpsuit',
@@ -74,6 +77,7 @@ describe('useTrendingFacets', () => {
       rerender({ transformItems: getItemPrice, indexName: 'test1' });
     });
 
+    await waitForNextUpdate();
     await waitFor(() => {
       expect(result.current.recommendations).toEqual([250]);
     });

--- a/packages/recommend-react/src/__tests__/useTrendingItems.test.ts
+++ b/packages/recommend-react/src/__tests__/useTrendingItems.test.ts
@@ -30,7 +30,7 @@ describe('useTrendingItems', () => {
   test('gets trending items', async () => {
     const { recommendClient } = createMockedRecommendClient();
 
-    const { result } = renderHook(() =>
+    const { result, waitForNextUpdate } = renderHook(() =>
       useTrendingItems({
         indexName: 'test',
         recommendClient,
@@ -46,6 +46,7 @@ describe('useTrendingItems', () => {
       })
     );
 
+    await waitForNextUpdate();
     await waitFor(() => {
       expect(result.current.recommendations).toEqual([hit]);
     });
@@ -54,7 +55,7 @@ describe('useTrendingItems', () => {
   test('assures that the transformItems function is applied properly after rerender', async () => {
     const { recommendClient } = createMockedRecommendClient();
 
-    const { result, rerender } = renderHook(
+    const { result, rerender, waitForNextUpdate } = renderHook(
       ({ transformItems, indexName }) =>
         useTrendingItems({
           indexName,
@@ -78,6 +79,8 @@ describe('useTrendingItems', () => {
         },
       }
     );
+
+    await waitForNextUpdate();
     await waitFor(() => {
       expect(result.current.recommendations).toEqual([
         'Landoh 4-Pocket Jumpsuit',
@@ -88,6 +91,7 @@ describe('useTrendingItems', () => {
       rerender({ transformItems: getItemPrice, indexName: 'test1' });
     });
 
+    await waitForNextUpdate();
     await waitFor(() => {
       expect(result.current.recommendations).toEqual([250]);
     });

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,3 @@
+import failOnConsole from 'jest-fail-on-console';
+
+failOnConsole({ shouldFailOnError: true, shouldFailOnWarn: true });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3647,6 +3647,13 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.21.3"
 
+ansi-escapes@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-6.0.0.tgz#68c580e87a489f6df3d761028bb93093fde6bd8a"
+  integrity sha512-IG23inYII3dWlU2EyiAiGj6Bwal5GzsgPMwjYGvc1HPE2dgbj4ZB5ToWBKSquKw74nB3TIuOwaI6/jSULzfgrw==
+  dependencies:
+    type-fest "^3.0.0"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
@@ -3671,6 +3678,11 @@ ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
+ansi-regex@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
+  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
 
 ansi-styles@^3.1.0, ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
@@ -4398,6 +4410,11 @@ chalk@^4.0.2, chalk@^4.1.1:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.2.0.tgz#249623b7d66869c673699fb66d65723e54dfcfb3"
+  integrity sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==
+
 change-case@4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/change-case/-/change-case-4.1.1.tgz"
@@ -4420,6 +4437,11 @@ char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
+
+char-regex@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-2.0.1.tgz#6dafdb25f9d3349914079f010ba8d0e6ff9cd01e"
+  integrity sha512-oSvEeo6ZUD7NepqAat3RqoucZ5SeqLJgOvVIwkafu6IP3V0pO38s/ypdVUmDDK6qIIHNlYHJAKX9E7R7HoKElw==
 
 chardet@^0.7.0:
   version "0.7.0"
@@ -7458,6 +7480,13 @@ jest-environment-node@^29.4.3:
     jest-mock "^29.4.3"
     jest-util "^29.4.3"
 
+jest-fail-on-console@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/jest-fail-on-console/-/jest-fail-on-console-3.0.2.tgz#4ab3c5f1986702c1dfa099cbf303767818f6d916"
+  integrity sha512-8vpH03d9n41jKCF/rcQz/nf0ksK2hlnOXTY5VUMqliPHPfT9F7L9CYOyhFNSQ+o6Aszsuja0GAXt1jz6sfDM8w==
+  dependencies:
+    chalk "^4.1.0"
+
 jest-get-type@^27.0.6:
   version "27.0.6"
   resolved "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.6.tgz"
@@ -7564,7 +7593,7 @@ jest-pnp-resolver@^1.2.2:
   resolved "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz"
   integrity sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==
 
-jest-regex-util@^29.4.3:
+jest-regex-util@^29.0.0, jest-regex-util@^29.4.3:
   version "29.4.3"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-29.4.3.tgz#a42616141e0cae052cfa32c169945d00c0aa0bb8"
   integrity sha512-O4FglZaMmWXbGHSQInfXewIsd1LMn9p3ZXB/6r4FOkyhX2/iP/soMG98jGvk/A3HAN78+5VWcBGO0BJAPRh4kg==
@@ -7713,7 +7742,20 @@ jest-validate@^29.4.3:
     leven "^3.1.0"
     pretty-format "^29.4.3"
 
-jest-watcher@^29.4.3:
+jest-watch-typeahead@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/jest-watch-typeahead/-/jest-watch-typeahead-2.2.2.tgz#5516d3cd006485caa5cfc9bd1de40f1f8b136abf"
+  integrity sha512-+QgOFW4o5Xlgd6jGS5X37i08tuuXNW8X0CV9WNFi+3n8ExCIP+E1melYhvYLjv5fE6D0yyzk74vsSO8I6GqtvQ==
+  dependencies:
+    ansi-escapes "^6.0.0"
+    chalk "^5.2.0"
+    jest-regex-util "^29.0.0"
+    jest-watcher "^29.0.0"
+    slash "^5.0.0"
+    string-length "^5.0.1"
+    strip-ansi "^7.0.1"
+
+jest-watcher@^29.0.0, jest-watcher@^29.4.3:
   version "29.4.3"
   resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-29.4.3.tgz#e503baa774f0c2f8f3c8db98a22ebf885f19c384"
   integrity sha512-zwlXH3DN3iksoIZNk73etl1HzKyi5FuQdYLnkQKm5BW4n8HpoG59xSwpVdFrnh60iRRaRBGw0gcymIxjJENPcA==
@@ -10737,6 +10779,11 @@ slash@^2.0.0:
   resolved "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz"
   integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
+slash@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-5.0.0.tgz#8c18a871096b71ee0e002976a4fe3374991c3074"
+  integrity sha512-n6KkmvKS0623igEVj3FF0OZs1gYYJ0o0Hj939yc1fyxl2xt+xYpLnzJB6xBSqOfV9ZFLEWodBBN/heZJahuIJQ==
+
 slice-ansi@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz"
@@ -10952,6 +10999,14 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
+string-length@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/string-length/-/string-length-5.0.1.tgz#3d647f497b6e8e8d41e422f7e0b23bc536c8381e"
+  integrity sha512-9Ep08KAMUn0OadnVaBuRdE2l615CQ508kr0XMadjClfYpdCyvrbFp6Taebo8yyxokQ4viUd/xPPUA4FGgUa0ow==
+  dependencies:
+    char-regex "^2.0.0"
+    strip-ansi "^7.0.1"
+
 string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
@@ -11074,6 +11129,13 @@ strip-ansi@^6.0.1:
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
+
+strip-ansi@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.0.1.tgz#61740a08ce36b61e50e65653f07060d000975fb2"
+  integrity sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==
+  dependencies:
+    ansi-regex "^6.0.1"
 
 strip-bom@^2.0.0:
   version "2.0.0"
@@ -11516,6 +11578,11 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-fest@^3.0.0:
+  version "3.5.7"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.5.7.tgz#1ee9efc9a172f4002c40b896689928a7bba537f2"
+  integrity sha512-6J4bYzb4sdkcLBty4XW7F18VPI66M4boXNE+CY40532oq2OJe6AVMB5NmjOp6skt/jw5mRjz/hLRpuglz0U+FA==
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
1- Introduced `waitForNextUpdate` to avoid the `act` verbose warning thrown when testing hooks. https://react-hooks-testing-library.com/usage/advanced-hooks#async

2- Added `jest-watch-typeahead` for better DX when running a subset of tests

3- Added `jest-fail-on-console` by @ValentinH 