### PR TITLE
fix: Fix transpilation errors in codesanbox demo examples

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -2,6 +2,6 @@
   "packages": ["packages/*"],
   "buildCommand": false,
   "^": "buildCommand is false because `yarn prepare` is going to build packages anyway.",
-  "sandboxes": ["/examples/demo", "/examples/js-demo"],
-  "node": "14"
+  "sandboxes": ["/examples/demo", "/examples/js-demo", "/examples/templating"],
+  "node": "18"
 }

--- a/examples/demo/src/components/BundleView/index.tsx
+++ b/examples/demo/src/components/BundleView/index.tsx
@@ -25,8 +25,8 @@ export function BundleView<TObject extends BaseObject>(
   props: BundleViewProps<TObject>
 ): JSX.Element {
   const items = Array.from(new Set([props.currentItem, ...props.items]));
-  const formatPrice = props.formatPrice ?? formatPriceDefault;
-  const getAmount = props.getAmount ?? getAmountDefault;
+  const formatPrice = props.formatPrice || formatPriceDefault;
+  const getAmount = props.getAmount || getAmountDefault;
 
   const [selectedItems, setSelectedItems] = useState(() => items);
   const [price, setPrice] = useState(() => getAmount(selectedItems));

--- a/examples/demo/src/routes/HomePage.tsx
+++ b/examples/demo/src/routes/HomePage.tsx
@@ -30,7 +30,8 @@ export const HomePage: React.FC = () => {
             insights={insights}
             onSelect={(facetHits) => {
               const isSameValue =
-                facetHits.facetValue === selectedFacetValue?.facetValue;
+                selectedFacetValue &&
+                facetHits.facetValue === selectedFacetValue.facetValue;
               setSelectedFacetValue(isSameValue ? null : facetHits);
             }}
             indexName={indexName}

--- a/examples/demo/src/routes/HomePage.tsx
+++ b/examples/demo/src/routes/HomePage.tsx
@@ -29,11 +29,9 @@ export const HomePage: React.FC = () => {
             hit={item}
             insights={insights}
             onSelect={(facetHits) => {
-              setSelectedFacetValue(
-                facetHits.facetValue === selectedFacetValue?.facetValue
-                  ? null
-                  : facetHits
-              );
+              const isSameValue =
+                facetHits.facetValue === selectedFacetValue?.facetValue;
+              setSelectedFacetValue(isSameValue ? null : facetHits);
             }}
             indexName={indexName}
           />

--- a/examples/js-demo/app.tsx
+++ b/examples/js-demo/app.tsx
@@ -186,7 +186,7 @@ function renderRecommendations(selectedProduct: ProductHit) {
               />
             );
           },
-          view: (...props) => horizontalSlider(...props) ?? <div>Loading</div>,
+          view: (...props) => horizontalSlider(...props) || <div>Loading</div>,
           maxRecommendations: 10,
           translations: {
             title: 'Related products (fallback)',
@@ -203,7 +203,7 @@ function renderRecommendations(selectedProduct: ProductHit) {
               `hierarchical_categories.lvl0:${selectedProduct.hierarchical_categories.lvl0}`,
             ],
           },
-        }) ?? <div>Loading...</div>
+        }) || <div>Loading...</div>
       );
     },
   });
@@ -222,7 +222,7 @@ function renderRecommendations(selectedProduct: ProductHit) {
         />
       );
     },
-    view: (...props) => horizontalSlider(...props) ?? <div>Loading</div>,
+    view: (...props) => horizontalSlider(...props) || <div>Loading</div>,
     maxRecommendations: 10,
     translations: {
       title: 'Related products',

--- a/examples/templating/createElement/index.ts
+++ b/examples/templating/createElement/index.ts
@@ -45,7 +45,7 @@ relatedProducts<ProductHit>({
         itemComponent({ item }) {
           return itemComponent({ item, createElement, Fragment });
         },
-      }) ?? createElement('div', null, 'Loading')
+      }) || createElement('div', null, 'Loading')
     );
   },
 });
@@ -64,7 +64,7 @@ trendingItems<ProductHit>({
         itemComponent({ item }) {
           return itemComponent({ item, createElement, Fragment });
         },
-      }) ?? createElement('div', null, 'Loading')
+      }) || createElement('div', null, 'Loading')
     );
   },
 });

--- a/examples/templating/createElement/productItem.ts
+++ b/examples/templating/createElement/productItem.ts
@@ -12,7 +12,7 @@ export function productItem({ item, createElement }: ProductItemProps) {
     createElement('div', { className: 'relative' }, [
       createElement('img', {
         className: 'max-h-80',
-        src: item.image_urls?.[0],
+        src: item.image_urls[0],
       }),
       createElement('div', { className: 'ProductItem-info relative' }, [
         createElement(

--- a/examples/templating/html/index.ts
+++ b/examples/templating/html/index.ts
@@ -43,7 +43,7 @@ relatedProducts<ProductHit>({
         itemComponent({ item }) {
           return itemComponent({ item, ...renderer });
         },
-      }) ?? renderer.html`<div>Loading</div>`
+      }) || renderer.html`<div>Loading</div>`
     );
   },
 });
@@ -61,7 +61,7 @@ trendingItems<ProductHit>({
         itemComponent({ item }) {
           return itemComponent({ item, ...renderer });
         },
-      }) ?? renderer.html`<div>Loading</div>`
+      }) || renderer.html`<div>Loading</div>`
     );
   },
 });

--- a/examples/templating/jsx/index.tsx
+++ b/examples/templating/jsx/index.tsx
@@ -35,7 +35,7 @@ relatedProducts<ProductHit>({
   container: '#relatedProducts',
   recommendClient,
   indexName,
-  view: (...props) => horizontalSlider(...props) ?? <div>Loading</div>,
+  view: (...props) => horizontalSlider(...props) || <div>Loading</div>,
   objectIDs: ['M0E20000000EAAK'],
   itemComponent({ item }) {
     return <ProductItem item={item} />;
@@ -46,7 +46,7 @@ trendingItems<ProductHit>({
   container: '#trendingItems',
   recommendClient,
   indexName,
-  view: (...props) => horizontalSlider(...props) ?? <div>Loading</div>,
+  view: (...props) => horizontalSlider(...props) || <div>Loading</div>,
   itemComponent({ item }) {
     return <ProductItem item={item} />;
   },

--- a/examples/templating/package.json
+++ b/examples/templating/package.json
@@ -9,17 +9,18 @@
     "start": "parcel index.html"
   },
   "dependencies": {
-    "@algolia/ui-components-horizontal-slider-js": "1.2.1",
-    "@algolia/ui-components-horizontal-slider-theme": "1.2.1",
-    "preact": "10.13.2"
-  },
-  "devDependencies": {
+    "algoliasearch": "4.17.0",
     "@algolia/client-search": "4.17.0",
     "@algolia/recommend": "4.17.0",
     "@algolia/recommend-js": "1.8.1",
     "@algolia/recommend-vdom": "1.8.1",
+    "@algolia/ui-components-horizontal-slider-js": "1.2.1",
+    "@algolia/ui-components-horizontal-slider-theme": "1.2.1",
+    "preact": "10.13.2"
+
+  },
+  "devDependencies": {
     "@babel/runtime": "7.21.0",
-    "algoliasearch": "4.17.0",
     "parcel": "2.8.3"
   }
 }


### PR DESCRIPTION
Current CodeSanbox template is broken because we can't use optional chaining and nullish coalescing. 

As a follow-up, I will investigate how to make the sandbox work with modern features.


How to review: 

1- Notice that these sandboxes are now broken. 

- https://codesandbox.io/s/github/algolia/recommend/tree/next/examples/demo
- https://codesandbox.io/s/github/algolia/recommend/tree/next/examples/js-demo
- https://codesandbox.io/s/github/algolia/recommend/tree/next/examples/templating


2- See that these sandboxes now work: 

- https://codesandbox.io/s/github/algolia/recommend/tree/fix-codesandbox-transpile-errors/examples/demo
- https://codesandbox.io/s/github/algolia/recommend/tree/fix-codesandbox-transpile-errors/examples/js-demo
- https://codesandbox.io/s/github/algolia/recommend/tree/fix-codesandbox-transpile-errors/examples/templating
