### PR TITLE
fix: remove vdom renderer from react props

### DIFF
--- a/packages/recommend-react/src/FrequentlyBoughtTogether.tsx
+++ b/packages/recommend-react/src/FrequentlyBoughtTogether.tsx
@@ -17,7 +17,10 @@ const UncontrolledFrequentlyBoughtTogether = createFrequentlyBoughtTogetherCompo
 export type FrequentlyBoughtTogetherProps<
   TObject
 > = GetFrequentlyBoughtTogetherProps<TObject> &
-  Omit<FrequentlyBoughtTogetherVDOMProps<TObject>, 'items' | 'status'>;
+  Omit<
+    FrequentlyBoughtTogetherVDOMProps<TObject>,
+    'items' | 'status' | 'createElement' | 'Fragment'
+  >;
 
 export function FrequentlyBoughtTogether<TObject>(
   props: FrequentlyBoughtTogetherProps<TObject>

--- a/packages/recommend-react/src/RelatedProducts.tsx
+++ b/packages/recommend-react/src/RelatedProducts.tsx
@@ -13,7 +13,10 @@ const UncontrolledRelatedProducts = createRelatedProductsComponent({
 });
 
 export type RelatedProductsProps<TObject> = GetRelatedProductsProps<TObject> &
-  Omit<RelatedProductsVDOMProps<TObject>, 'items' | 'status'>;
+  Omit<
+    RelatedProductsVDOMProps<TObject>,
+    'items' | 'status' | 'createElement' | 'Fragment'
+  >;
 
 export function RelatedProducts<TObject>(props: RelatedProductsProps<TObject>) {
   const { recommendations, status } = useRelatedProducts<TObject>(props);

--- a/packages/recommend-react/src/TrendingFacets.tsx
+++ b/packages/recommend-react/src/TrendingFacets.tsx
@@ -13,7 +13,10 @@ const UncontrolledTrendingFacets = createTrendingFacetsComponent({
 });
 
 export type TrendingFacetsProps<TObject> = GetTrendingFacetsProps<TObject> &
-  Omit<TrendingFacetsVDOMProps<TObject>, 'items' | 'status'>;
+  Omit<
+    TrendingFacetsVDOMProps<TObject>,
+    'items' | 'status' | 'createElement' | 'Fragment'
+  >;
 
 export function TrendingFacets<TObject>(props: TrendingFacetsProps<TObject>) {
   const { recommendations, status } = useTrendingFacets<TObject>(props);

--- a/packages/recommend-react/src/TrendingItems.tsx
+++ b/packages/recommend-react/src/TrendingItems.tsx
@@ -13,7 +13,10 @@ const UncontrolledTrendingItems = createTrendingItemsComponent({
 });
 
 export type TrendingItemsProps<TObject> = GetTrendingItemsProps<TObject> &
-  Omit<TrendingItemsVDOMProps<TObject>, 'items' | 'status'>;
+  Omit<
+    TrendingItemsVDOMProps<TObject>,
+    'items' | 'status' | 'createElement' | 'Fragment'
+  >;
 
 export function TrendingItems<TObject>(props: TrendingItemsProps<TObject>) {
   const { recommendations, status } = useTrendingItems<TObject>(props);


### PR DESCRIPTION
As internally reported by @sarahdayan 

> There seems to be an issue with the types in @algolia/recommend-react for the view prop in the RelatedProducts component.
It requires a renderer (createElement and Fragment) which seems to be inherited from the underlying VDOM package (which makes sense) but in React the renderer shouldn't be required since it's provided.

The proposed fix is to omit `Renderer`[props](https://github.com/algolia/recommend/blob/next/packages/recommend-vdom/src/types/Renderer.ts#L26) from the react components.