### PR TITLE
feat: add enabled prop

### DIFF
--- a/packages/recommend-react/src/FrequentlyBoughtTogether.tsx
+++ b/packages/recommend-react/src/FrequentlyBoughtTogether.tsx
@@ -17,7 +17,7 @@ const UncontrolledFrequentlyBoughtTogether = createFrequentlyBoughtTogetherCompo
 
 export type UseFrequentlyBoughtTogetherProps<TObject> = OptionalRecommendClient<
   GetFrequentlyBoughtTogetherProps<TObject>
->;
+> & { enabled?: boolean };
 
 export type FrequentlyBoughtTogetherProps<
   TObject

--- a/packages/recommend-react/src/RelatedProducts.tsx
+++ b/packages/recommend-react/src/RelatedProducts.tsx
@@ -15,7 +15,7 @@ const UncontrolledRelatedProducts = createRelatedProductsComponent({
 
 export type UseRelatedProductsProps<TObject> = OptionalRecommendClient<
   GetRelatedProductsProps<TObject>
->;
+> & { enabled?: boolean };
 
 export type RelatedProductsProps<TObject> = UseRelatedProductsProps<TObject> &
   Omit<

--- a/packages/recommend-react/src/TrendingFacets.tsx
+++ b/packages/recommend-react/src/TrendingFacets.tsx
@@ -13,7 +13,7 @@ const UncontrolledTrendingFacets = createTrendingFacetsComponent({
   Fragment,
 });
 
-export type UseTrendingFacetsProps = OptionalRecommendClient<GetTrendingFacetsProps>;
+export type UseTrendingFacetsProps = OptionalRecommendClient<GetTrendingFacetsProps> & { enabled?: boolean };
 
 export type TrendingFacetsProps = UseTrendingFacetsProps &
   Omit<

--- a/packages/recommend-react/src/TrendingItems.tsx
+++ b/packages/recommend-react/src/TrendingItems.tsx
@@ -15,7 +15,7 @@ const UncontrolledTrendingItems = createTrendingItemsComponent({
 
 export type UseTrendingItemsProps<TObject> = OptionalRecommendClient<
   GetTrendingItemsProps<TObject>
->;
+> & { enabled?: boolean };
 
 export type TrendingItemsProps<TObject> = UseTrendingItemsProps<TObject> &
   Omit<

--- a/packages/recommend-react/src/useFrequentlyBoughtTogether.ts
+++ b/packages/recommend-react/src/useFrequentlyBoughtTogether.ts
@@ -12,6 +12,7 @@ import { useStableValue } from './useStableValue';
 import { useStatus } from './useStatus';
 
 export function useFrequentlyBoughtTogether<TObject>({
+  enabled = true,
   indexName,
   maxRecommendations,
   objectIDs: userObjectIDs,
@@ -40,6 +41,10 @@ export function useFrequentlyBoughtTogether<TObject>({
   }, [userTransformItems]);
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     const param = {
       indexName,
       maxRecommendations,
@@ -92,6 +97,7 @@ export function useFrequentlyBoughtTogether<TObject>({
     });
     return () => {};
   }, [
+    enabled,
     indexName,
     maxRecommendations,
     objectIDs,

--- a/packages/recommend-react/src/useRecommendations.ts
+++ b/packages/recommend-react/src/useRecommendations.ts
@@ -9,9 +9,12 @@ import { useAlgoliaAgent } from './useAlgoliaAgent';
 import { useStableValue } from './useStableValue';
 import { useStatus } from './useStatus';
 
-export type UseRecommendationsProps<TObject> = GetRecommendationsProps<TObject>;
+export type UseRecommendationsProps<
+  TObject
+> = GetRecommendationsProps<TObject> & { enabled?: boolean };
 
 export function useRecommendations<TObject>({
+  enabled = true,
   fallbackParameters: userFallbackParameters,
   indexName,
   maxRecommendations,
@@ -38,6 +41,10 @@ export function useRecommendations<TObject>({
   }, [userTransformItems]);
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     setStatus('loading');
     getRecommendations({
       fallbackParameters,
@@ -54,6 +61,7 @@ export function useRecommendations<TObject>({
       setStatus('idle');
     });
   }, [
+    enabled,
     fallbackParameters,
     indexName,
     maxRecommendations,

--- a/packages/recommend-react/src/useRelatedProducts.ts
+++ b/packages/recommend-react/src/useRelatedProducts.ts
@@ -12,6 +12,7 @@ import { useStableValue } from './useStableValue';
 import { useStatus } from './useStatus';
 
 export function useRelatedProducts<TObject>({
+  enabled = true,
   fallbackParameters: userFallbackParameters,
   indexName,
   maxRecommendations,
@@ -42,6 +43,10 @@ export function useRelatedProducts<TObject>({
   }, [userTransformItems]);
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     const param = {
       fallbackParameters,
       indexName,
@@ -97,6 +102,7 @@ export function useRelatedProducts<TObject>({
     return () => {};
   }, [
     client,
+    enabled,
     fallbackParameters,
     hasProvider,
     indexName,

--- a/packages/recommend-react/src/useTrendingFacets.ts
+++ b/packages/recommend-react/src/useTrendingFacets.ts
@@ -12,6 +12,7 @@ import { useAlgoliaAgent } from './useAlgoliaAgent';
 import { useStatus } from './useStatus';
 
 export function useTrendingFacets({
+  enabled = true,
   indexName,
   maxRecommendations,
   recommendClient,
@@ -37,6 +38,10 @@ export function useTrendingFacets({
   }, [userTransformItems]);
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     const param = {
       model: 'trending-facets' as TrendingModel,
       indexName,
@@ -84,6 +89,7 @@ export function useTrendingFacets({
     });
     return () => {};
   }, [
+    enabled,
     indexName,
     maxRecommendations,
     client,

--- a/packages/recommend-react/src/useTrendingItems.ts
+++ b/packages/recommend-react/src/useTrendingItems.ts
@@ -12,6 +12,7 @@ import { useStableValue } from './useStableValue';
 import { useStatus } from './useStatus';
 
 export function useTrendingItems<TObject>({
+  enabled = true,
   fallbackParameters: userFallbackParameters,
   indexName,
   maxRecommendations,
@@ -42,6 +43,10 @@ export function useTrendingItems<TObject>({
   }, [userTransformItems]);
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     const param: BatchQuery<TObject> = {
       model: 'trending-items',
       fallbackParameters,
@@ -88,6 +93,7 @@ export function useTrendingItems<TObject>({
     });
     return () => {};
   }, [
+    enabled,
     fallbackParameters,
     indexName,
     maxRecommendations,


### PR DESCRIPTION
This PR adds `enabled` prop to hooks, thus to allow controlling when the fetching will start.  It is inspired by react query's [same-named prop](https://tanstack.com/query/v4/docs/react/guides/disabling-queries#lazy-queries).