### PR TITLE
chore: update application to use new application id

### DIFF
--- a/examples/demo/src/config.ts
+++ b/examples/demo/src/config.ts
@@ -1,3 +1,3 @@
-export const appId = 'XX85YRZZMV';
-export const apiKey = '098f71f9e2267178bdfc08cc986d2999';
-export const indexName = 'test_FLAGSHIP_ECOM_recommend';
+export const appId = '93MWK2GLFE';
+export const apiKey = '63a2f2cf276ced37f901d8612ce5b40c';
+export const indexName = 'prod_ECOM';

--- a/examples/js-demo/app.tsx
+++ b/examples/js-demo/app.tsx
@@ -18,9 +18,9 @@ import { ProductHit, ReferenceItemProps } from './types';
 import '@algolia/autocomplete-theme-classic';
 import '@algolia/ui-components-horizontal-slider-theme';
 
-const appId = 'XX85YRZZMV';
-const apiKey = '098f71f9e2267178bdfc08cc986d2999';
-const indexName = 'test_FLAGSHIP_ECOM_recommend';
+const appId = '93MWK2GLFE';
+const apiKey = '63a2f2cf276ced37f901d8612ce5b40c';
+const indexName = 'prod_ECOM';
 
 const searchClient = algoliasearch(appId, apiKey);
 const recommendClient = algoliarecommend(appId, apiKey);

--- a/examples/templating/createElement/index.ts
+++ b/examples/templating/createElement/index.ts
@@ -14,11 +14,11 @@ import { productItem } from './productItem';
 
 import '@algolia/ui-components-horizontal-slider-theme';
 
-const indexName = 'test_FLAGSHIP_ECOM_recommend';
+const indexName = 'prod_ECOM';
 
 const recommendClient = algoliarecommend(
-  'XX85YRZZMV',
-  '098f71f9e2267178bdfc08cc986d2999'
+  '93MWK2GLFE',
+  '63a2f2cf276ced37f901d8612ce5b40c'
 );
 
 frequentlyBoughtTogether<ProductHit>({

--- a/examples/templating/html/index.ts
+++ b/examples/templating/html/index.ts
@@ -14,11 +14,11 @@ import { productItem } from './productItem';
 
 import '@algolia/ui-components-horizontal-slider-theme';
 
-const indexName = 'test_FLAGSHIP_ECOM_recommend';
+const indexName = 'prod_ECOM';
 
 const recommendClient = algoliarecommend(
-  'XX85YRZZMV',
-  '098f71f9e2267178bdfc08cc986d2999'
+  '93MWK2GLFE',
+  '63a2f2cf276ced37f901d8612ce5b40c'
 );
 
 frequentlyBoughtTogether<ProductHit>({

--- a/examples/templating/jsx/index.tsx
+++ b/examples/templating/jsx/index.tsx
@@ -15,11 +15,11 @@ import { ProductHit } from '../types/ProductHit';
 
 import { ProductItem } from './ProductItem';
 
-const indexName = 'test_FLAGSHIP_ECOM_recommend';
+const indexName = 'prod_ECOM';
 
 const recommendClient = algoliarecommend(
-  'XX85YRZZMV',
-  '098f71f9e2267178bdfc08cc986d2999'
+  '93MWK2GLFE',
+  '63a2f2cf276ced37f901d8612ce5b40c'
 );
 
 frequentlyBoughtTogether<ProductHit>({


### PR DESCRIPTION
We were using an application generously maintained by @shortcuts 

I propose we change the demo applications to use Recommend owned Flagship app.