### PR TITLE
feat: export experimental-personalization in recommend-js & recommend-react

### DIFF
--- a/examples/demo/src/routes/HomePage.tsx
+++ b/examples/demo/src/routes/HomePage.tsx
@@ -1,9 +1,6 @@
 import algoliarecommend from '@algolia/recommend';
-import {
-  TrendingFacets,
-  TrendingItems,
-  RecommendedForYou,
-} from '@algolia/recommend-react';
+import { TrendingFacets, RecommendedForYou } from '@algolia/recommend-react';
+import { TrendingItems } from '@algolia/recommend-react/dist/esm/experimental-personalization';
 import { HorizontalSlider } from '@algolia/ui-components-horizontal-slider-react';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';

--- a/examples/demo/src/routes/HomePage.tsx
+++ b/examples/demo/src/routes/HomePage.tsx
@@ -3,7 +3,7 @@ import {
   TrendingItems,
   TrendingFacets,
   RecommendedForYou,
-} from '@algolia/recommend-react/dist/umd/experimental-personalization';
+} from '@algolia/recommend-react/dist/esm/experimental-personalization';
 import { HorizontalSlider } from '@algolia/ui-components-horizontal-slider-react';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';

--- a/examples/demo/src/routes/HomePage.tsx
+++ b/examples/demo/src/routes/HomePage.tsx
@@ -1,6 +1,9 @@
 import algoliarecommend from '@algolia/recommend';
-import { TrendingFacets, RecommendedForYou } from '@algolia/recommend-react';
-import { TrendingItems } from '@algolia/recommend-react/dist/esm/experimental-personalization';
+import {
+  TrendingItems,
+  TrendingFacets,
+  RecommendedForYou,
+} from '@algolia/recommend-react/dist/umd/experimental-personalization';
 import { HorizontalSlider } from '@algolia/ui-components-horizontal-slider-react';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -44,14 +47,10 @@ export const HomePage: React.FC = () => {
         }}
       />
       <TrendingItems<ProductHit>
+        region="eu"
+        userToken="aaaa"
         indexName={indexName}
         recommendClient={recommendClient}
-        experimental={{
-          personalization: {
-            region: 'eu',
-            userToken: 'likes-gender-men',
-          },
-        }}
         facetName={selectedFacetValue ? 'brand' : undefined}
         facetValue={
           selectedFacetValue ? selectedFacetValue.facetValue : undefined

--- a/examples/demo/src/routes/ProductPage.tsx
+++ b/examples/demo/src/routes/ProductPage.tsx
@@ -1,10 +1,11 @@
 import algoliarecommend from '@algolia/recommend';
 import {
+  Recommend,
   FrequentlyBoughtTogether,
   RelatedProducts,
   LookingSimilar,
-} from '@algolia/recommend-react';
-import { Recommend } from '@algolia/recommend-react/dist/esm/experimental-personalization';
+} from '@algolia/recommend-react/dist/esm/experimental-personalization';
+// import { FrequentlyBoughtTogether } from '@algolia/recommend-react/dist/esm/experimental-personalization';
 import { HorizontalSlider } from '@algolia/ui-components-horizontal-slider-react';
 import algoliasearch from 'algoliasearch';
 import React, { useEffect } from 'react';
@@ -49,15 +50,7 @@ export const ProductPage: React.FC = () => {
   }
 
   return (
-    <Recommend
-      recommendClient={recommendClient}
-      experimental={{
-        personalization: {
-          region: 'eu',
-          userToken: 'likes-gender-men',
-        },
-      }}
-    >
+    <Recommend recommendClient={recommendClient}>
       <div style={{ padding: '1rem 0' }}>
         <div
           className="Hit"
@@ -94,6 +87,7 @@ export const ProductPage: React.FC = () => {
         }}
       />
       <FrequentlyBoughtTogether<ProductHit>
+        recommendClient={recommendClient}
         indexName={indexName}
         objectIDs={[selectedProduct.objectID]}
         itemComponent={({ item }) => (
@@ -103,6 +97,8 @@ export const ProductPage: React.FC = () => {
             insights={insights}
           />
         )}
+        userToken="likes-gender-men"
+        region="eu"
         maxRecommendations={2}
         queryParameters={{
           analytics: true,

--- a/examples/demo/src/routes/ProductPage.tsx
+++ b/examples/demo/src/routes/ProductPage.tsx
@@ -3,8 +3,8 @@ import {
   FrequentlyBoughtTogether,
   RelatedProducts,
   LookingSimilar,
-  Recommend,
 } from '@algolia/recommend-react';
+import { Recommend } from '@algolia/recommend-react/dist/esm/experimental-personalization';
 import { HorizontalSlider } from '@algolia/ui-components-horizontal-slider-react';
 import algoliasearch from 'algoliasearch';
 import React, { useEffect } from 'react';

--- a/examples/js-demo/app.tsx
+++ b/examples/js-demo/app.tsx
@@ -201,12 +201,8 @@ function renderRecommendations(selectedProduct: ProductHit) {
     recommendClient,
     indexName,
     objectIDs: [selectedProduct.objectID],
-    experimental: {
-      personalization: {
-        region: 'eu',
-        userToken: 'likes-gender-men',
-      },
-    },
+    userToken: 'likes-gender-men',
+    region: 'eu',
     itemComponent({ item }) {
       return (
         <RelatedItem

--- a/examples/js-demo/app.tsx
+++ b/examples/js-demo/app.tsx
@@ -112,7 +112,7 @@ trendingFacets({
   view: (props) => {
     return (
       <div className="Facets-Wrapper">
-        {props[0].items.map((item) => {
+        {props.items.map((item) => {
           return <Facet key={item.facetValue} hit={item} />;
         })}
       </div>

--- a/examples/js-demo/app.tsx
+++ b/examples/js-demo/app.tsx
@@ -5,10 +5,10 @@ import algoliarecommend from '@algolia/recommend';
 import {
   frequentlyBoughtTogether,
   relatedProducts,
-  lookingSimilar,
   trendingFacets,
   recommendedForYou,
 } from '@algolia/recommend-js';
+import { lookingSimilar } from '@algolia/recommend-js/dist/esm/experimental-personalization';
 import { horizontalSlider } from '@algolia/ui-components-horizontal-slider-js';
 import algoliasearch from 'algoliasearch';
 import { h, render } from 'preact';

--- a/packages/recommend-core/src/getBatchRecommendations.ts
+++ b/packages/recommend-core/src/getBatchRecommendations.ts
@@ -7,7 +7,7 @@ import {
 
 import { getPersonalizationFilters } from './personalization';
 import { ProductRecord, TrendingFacetHit } from './types';
-import { Experimental } from './types/Experimental';
+import { Personalization } from './types/Personalization';
 import { mapByScoreToRecommendations, mapToRecommendations } from './utils';
 import { version } from './version';
 
@@ -30,11 +30,7 @@ export type GetBatchRecommendations<TObject> = {
   keys: BatchKeyPair[];
   queries: Array<BatchQuery<TObject>>;
   recommendClient: RecommendClient;
-  /**
-   * Experimental features not covered by SLA and semantic versioning conventions.
-   */
-  experimental?: Experimental;
-};
+} & Personalization;
 
 export type BatchRecommendations<TObject> = {
   recommendations: Array<ProductRecord<TObject>>;
@@ -57,7 +53,8 @@ export async function getBatchRecommendations<TObject>({
   keys,
   queries,
   recommendClient,
-  experimental,
+  region,
+  userToken,
 }: GetBatchRecommendations<TObject>): Promise<
   Record<string, BatchRecommendations<TObject>>
 > {
@@ -69,15 +66,12 @@ export async function getBatchRecommendations<TObject>({
    * Big block of duplicated code, but it is fine since it is experimental and will be ported to the API eventually.
    * This is a temporary solution to get recommended personalization.
    */
-  if (
-    experimental?.personalization?.region &&
-    experimental?.personalization?.userToken
-  ) {
+  if (region && userToken) {
     const personalizationFilters = await getPersonalizationFilters({
       apiKey: recommendClient.transporter.queryParameters['x-algolia-api-key'],
       appId: recommendClient.appId,
-      region: experimental.personalization.region,
-      userToken: experimental.personalization.userToken,
+      region,
+      userToken,
     });
 
     _queries = queries.map((query) => {

--- a/packages/recommend-core/src/getFrequentlyBoughtTogether.ts
+++ b/packages/recommend-core/src/getFrequentlyBoughtTogether.ts
@@ -19,7 +19,8 @@ export function getFrequentlyBoughtTogether<TObject>({
   maxRecommendations,
   queryParameters,
   threshold,
-  experimental,
+  region,
+  userToken,
 }: GetFrequentlyBoughtTogetherProps<TObject>) {
   recommendClient.addAlgoliaAgent('recommend-core', version);
 
@@ -27,15 +28,12 @@ export function getFrequentlyBoughtTogether<TObject>({
    * Big block of duplicated code, but it is fine since it is experimental and will be ported to the API eventually.
    * This is a temporary solution to get recommended personalization.
    */
-  if (
-    experimental?.personalization?.region &&
-    experimental?.personalization?.userToken
-  ) {
+  if (region && userToken) {
     return getPersonalizationFilters({
       apiKey: recommendClient.transporter.queryParameters['x-algolia-api-key'],
       appId: recommendClient.appId,
-      region: experimental.personalization.region,
-      userToken: experimental.personalization.userToken,
+      region,
+      userToken,
     }).then((personalizationFilters) => {
       const queries = objectIDs.map((objectID) => ({
         indexName,

--- a/packages/recommend-core/src/getLookingSimilar.ts
+++ b/packages/recommend-core/src/getLookingSimilar.ts
@@ -18,7 +18,8 @@ export function getLookingSimilar<TObject>({
   maxRecommendations,
   queryParameters,
   threshold,
-  experimental,
+  region,
+  userToken,
 }: GetLookingSimilarProps<TObject>) {
   recommendClient.addAlgoliaAgent('recommend-core', version);
 
@@ -26,15 +27,12 @@ export function getLookingSimilar<TObject>({
    * Big block of duplicated code, but it is fine since it is experimental and will be ported to the API eventually.
    * This is a temporary solution to get recommended personalization.
    */
-  if (
-    experimental?.personalization?.region &&
-    experimental?.personalization?.userToken
-  ) {
+  if (region && userToken) {
     return getPersonalizationFilters({
       apiKey: recommendClient.transporter.queryParameters['x-algolia-api-key'],
       appId: recommendClient.appId,
-      region: experimental.personalization.region,
-      userToken: experimental.personalization.userToken,
+      region,
+      userToken,
     }).then((personalizationFilters) => {
       const queries = objectIDs.map((objectID) => ({
         fallbackParameters,

--- a/packages/recommend-core/src/getRecommendations.ts
+++ b/packages/recommend-core/src/getRecommendations.ts
@@ -2,7 +2,7 @@ import type { RecommendClient, RecommendationsQuery } from '@algolia/recommend';
 
 import { getPersonalizationFilters } from './personalization';
 import { ProductRecord, RecordWithObjectID } from './types';
-import { Experimental } from './types/Experimental';
+import { Personalization } from './types/Personalization';
 import { mapToRecommendations } from './utils';
 import { version } from './version';
 
@@ -23,12 +23,7 @@ export type RecommendationsProps<TObject> = {
   transformItems?: (
     items: Array<ProductRecord<TObject>>
   ) => Array<ProductRecord<TObject>>;
-
-  /**
-   * Experimental features not covered by SLA and semantic versioning conventions.
-   */
-  experimental?: Experimental;
-};
+} & Personalization;
 
 export type GetRecommendationsProps<TObject> = RecommendationsProps<TObject> &
   Omit<RecommendationsQuery, 'objectID'>;
@@ -47,7 +42,8 @@ export function getRecommendations<TObject>({
   model,
   queryParameters,
   threshold,
-  experimental,
+  region,
+  userToken,
 }: GetRecommendationsProps<TObject>): Promise<
   GetRecommendationsResult<TObject>
 > {
@@ -57,15 +53,12 @@ export function getRecommendations<TObject>({
    * Big block of duplicated code, but it is fine since it is experimental and will be ported to the API eventually.
    * This is a temporary solution to get recommended personalization.
    */
-  if (
-    experimental?.personalization?.region &&
-    experimental?.personalization?.userToken
-  ) {
+  if (region && userToken) {
     return getPersonalizationFilters({
       apiKey: recommendClient.transporter.queryParameters['x-algolia-api-key'],
       appId: recommendClient.appId,
-      region: experimental.personalization.region,
-      userToken: experimental.personalization.userToken,
+      region,
+      userToken,
     }).then((personalizationFilters) => {
       const queries = objectIDs.map((objectID) => ({
         fallbackParameters,

--- a/packages/recommend-core/src/getRelatedProducts.ts
+++ b/packages/recommend-core/src/getRelatedProducts.ts
@@ -18,7 +18,8 @@ export function getRelatedProducts<TObject>({
   maxRecommendations,
   queryParameters,
   threshold,
-  experimental,
+  region,
+  userToken,
 }: GetRelatedProductsProps<TObject>) {
   recommendClient.addAlgoliaAgent('recommend-core', version);
 
@@ -26,15 +27,12 @@ export function getRelatedProducts<TObject>({
    * Big block of duplicated code, but it is fine since it is experimental and will be ported to the API eventually.
    * This is a temporary solution to get recommended personalization.
    */
-  if (
-    experimental?.personalization?.region &&
-    experimental?.personalization?.userToken
-  ) {
+  if (region && userToken) {
     return getPersonalizationFilters({
       apiKey: recommendClient.transporter.queryParameters['x-algolia-api-key'],
       appId: recommendClient.appId,
-      region: experimental.personalization.region,
-      userToken: experimental.personalization.userToken,
+      region,
+      userToken,
     }).then((personalizationFilters) => {
       const queries = objectIDs.map((objectID) => ({
         fallbackParameters,

--- a/packages/recommend-core/src/getTrendingItems.ts
+++ b/packages/recommend-core/src/getTrendingItems.ts
@@ -2,7 +2,7 @@ import { RecommendClient, TrendingItemsQuery } from '@algolia/recommend';
 
 import { getPersonalizationFilters } from './personalization';
 import { ProductRecord } from './types';
-import { Experimental } from './types/Experimental';
+import { Personalization } from './types/Personalization';
 import { mapByScoreToRecommendations, uniqBy } from './utils';
 import { version } from './version';
 
@@ -19,12 +19,7 @@ export type TrendingItemsProps<TObject> = {
   transformItems?: (
     items: Array<ProductRecord<TObject>>
   ) => Array<ProductRecord<TObject>>;
-
-  /**
-   * Experimental features not covered by SLA and semantic versioning conventions.
-   */
-  experimental?: Experimental;
-};
+} & Personalization;
 
 export type GetTrendingItemsResult<TObject> = {
   recommendations: Array<ProductRecord<TObject>>;
@@ -43,7 +38,8 @@ export function getTrendingItems<TObject>({
   threshold,
   facetName,
   facetValue,
-  experimental,
+  userToken,
+  region,
 }: GetTrendingItemsProps<TObject>) {
   recommendClient.addAlgoliaAgent('recommend-core', version);
 
@@ -51,15 +47,12 @@ export function getTrendingItems<TObject>({
    * Big block of duplicated code, but it is fine since it is experimental and will be ported to the API eventually.
    * This is a temporary solution to get recommended personalization.
    */
-  if (
-    experimental?.personalization?.region &&
-    experimental?.personalization?.userToken
-  ) {
+  if (region && userToken) {
     return getPersonalizationFilters({
       apiKey: recommendClient.transporter.queryParameters['x-algolia-api-key'],
       appId: recommendClient.appId,
-      region: experimental.personalization.region,
-      userToken: experimental.personalization.userToken,
+      region,
+      userToken,
     }).then((personalizationFilters) => {
       const query = {
         fallbackParameters,

--- a/packages/recommend-core/src/types/Experimental.ts
+++ b/packages/recommend-core/src/types/Experimental.ts
@@ -1,6 +1,0 @@
-export type Experimental = {
-  personalization?: {
-    userToken: string;
-    region: 'us' | 'eu';
-  };
-};

--- a/packages/recommend-core/src/types/Personalization.ts
+++ b/packages/recommend-core/src/types/Personalization.ts
@@ -1,0 +1,4 @@
+export type Personalization = {
+  userToken?: string;
+  region?: 'us' | 'eu';
+};

--- a/packages/recommend-core/src/types/index.ts
+++ b/packages/recommend-core/src/types/index.ts
@@ -2,4 +2,4 @@ export * from './ProductRecord';
 export * from './RecommendModel';
 export * from './RecordWithObjectID';
 export * from './TrendingFacetHit';
-export * from './Experimental';
+export * from './Personalization';

--- a/packages/recommend-js/package.json
+++ b/packages/recommend-js/package.json
@@ -8,11 +8,14 @@
     "name": "Algolia, Inc.",
     "url": "https://www.algolia.com"
   },
-  "source": "src/index.ts",
+  "source": {
+    "index": "src/index.ts",
+    "experimental-personalization": "src/experimental-personalization/index.ts"
+  },
   "types": "dist/esm/index.d.ts",
   "module": "dist/esm/index.js",
   "main": "dist/umd/index.js",
-  "umd:main": "dist/umd/index.js",
+  "umd:main": "dist/umd",
   "unpkg": "dist/umd/index.js",
   "jsdelivr": "dist/umd/index.js",
   "sideEffects": false,

--- a/packages/recommend-js/package.json
+++ b/packages/recommend-js/package.json
@@ -17,7 +17,6 @@
   "types": "dist/esm/index.d.ts",
   "module": "dist/esm/index.js",
   "main": "dist/umd/index.js",
-  "experimental-personalization": "dist/umd/experimental-personalization/index.js",
   "unpkg": "dist/umd/index.js",
   "jsdelivr": "dist/umd/index.js",
   "sideEffects": false,

--- a/packages/recommend-js/package.json
+++ b/packages/recommend-js/package.json
@@ -9,13 +9,15 @@
     "url": "https://www.algolia.com"
   },
   "source": {
-    "index": "src/index.ts",
+    "main": "src/index.ts",
     "experimental-personalization": "src/experimental-personalization/index.ts"
   },
+  "umd:main": "dist/umd/index.js",
+  "umd:experimental-personalization": "dist/umd/experimental-personalization/index.js",
   "types": "dist/esm/index.d.ts",
   "module": "dist/esm/index.js",
   "main": "dist/umd/index.js",
-  "umd:main": "dist/umd",
+  "experimental-personalization": "dist/umd/experimental-personalization/index.js",
   "unpkg": "dist/umd/index.js",
   "jsdelivr": "dist/umd/index.js",
   "sideEffects": false,

--- a/packages/recommend-js/package.json
+++ b/packages/recommend-js/package.json
@@ -8,12 +8,8 @@
     "name": "Algolia, Inc.",
     "url": "https://www.algolia.com"
   },
-  "source": {
-    "main": "src/index.ts",
-    "experimental-personalization": "src/experimental-personalization/index.ts"
-  },
+  "source": "src/index.ts",
   "umd:main": "dist/umd/index.js",
-  "umd:experimental-personalization": "dist/umd/experimental-personalization/index.js",
   "types": "dist/esm/index.d.ts",
   "module": "dist/esm/index.js",
   "main": "dist/umd/index.js",

--- a/packages/recommend-js/src/experimental-personalization/frequentlyBoughtTogether.tsx
+++ b/packages/recommend-js/src/experimental-personalization/frequentlyBoughtTogether.tsx
@@ -1,26 +1,18 @@
 /** @jsxRuntime classic */
 /** @jsx h */
 
+import { Personalization } from '@algolia/recommend-core';
+
 import {
   FrequentlyBoughtTogetherProps,
   frequentlyBoughtTogether as render,
 } from '../frequentlyBoughtTogether';
 import { EnvironmentProps, HTMLTemplate } from '../types';
 
-import { Personalization } from './types';
-
 type Props<TObject> = FrequentlyBoughtTogetherProps<TObject, HTMLTemplate> &
   EnvironmentProps &
   Personalization;
 
 export function frequentlyBoughtTogether<TObject>(props: Props<TObject>) {
-  return render({
-    ...props,
-    experimental: {
-      personalization: {
-        userToken: props.userToken,
-        region: props.region,
-      },
-    },
-  });
+  return render<TObject>(props);
 }

--- a/packages/recommend-js/src/experimental-personalization/frequentlyBoughtTogether.tsx
+++ b/packages/recommend-js/src/experimental-personalization/frequentlyBoughtTogether.tsx
@@ -1,23 +1,26 @@
 /** @jsxRuntime classic */
 /** @jsx h */
-import { GetFrequentlyBoughtTogetherProps } from '@algolia/recommend-core';
-import { FrequentlyBoughtTogetherProps as FrequentlyBoughtTogetherVDOMProps } from '@algolia/recommend-vdom';
 
-import { frequentlyBoughtTogether as render } from '../frequentlyBoughtTogether';
+import {
+  FrequentlyBoughtTogetherProps,
+  frequentlyBoughtTogether as render,
+} from '../frequentlyBoughtTogether';
 import { EnvironmentProps, HTMLTemplate } from '../types';
 
-type FrequentlyBoughtTogetherProps<
-  TObject,
-  TComponentProps extends Record<string, unknown> = {}
-> = GetFrequentlyBoughtTogetherProps<TObject> &
-  Omit<
-    FrequentlyBoughtTogetherVDOMProps<TObject, TComponentProps>,
-    'items' | 'status'
-  >;
+import { Personalization } from './types';
 
-export function frequentlyBoughtTogether<TObject>({
-  experimental,
-  ...props
-}: FrequentlyBoughtTogetherProps<TObject, HTMLTemplate> & EnvironmentProps) {
-  return render(props);
+type Props<TObject> = FrequentlyBoughtTogetherProps<TObject, HTMLTemplate> &
+  EnvironmentProps &
+  Personalization;
+
+export function frequentlyBoughtTogether<TObject>(props: Props<TObject>) {
+  return render({
+    ...props,
+    experimental: {
+      personalization: {
+        userToken: props.userToken,
+        region: props.region,
+      },
+    },
+  });
 }

--- a/packages/recommend-js/src/experimental-personalization/frequentlyBoughtTogether.tsx
+++ b/packages/recommend-js/src/experimental-personalization/frequentlyBoughtTogether.tsx
@@ -1,0 +1,23 @@
+/** @jsxRuntime classic */
+/** @jsx h */
+import { GetFrequentlyBoughtTogetherProps } from '@algolia/recommend-core';
+import { FrequentlyBoughtTogetherProps as FrequentlyBoughtTogetherVDOMProps } from '@algolia/recommend-vdom';
+
+import { frequentlyBoughtTogether as render } from '../frequentlyBoughtTogether';
+import { EnvironmentProps, HTMLTemplate } from '../types';
+
+type FrequentlyBoughtTogetherProps<
+  TObject,
+  TComponentProps extends Record<string, unknown> = {}
+> = GetFrequentlyBoughtTogetherProps<TObject> &
+  Omit<
+    FrequentlyBoughtTogetherVDOMProps<TObject, TComponentProps>,
+    'items' | 'status'
+  >;
+
+export function frequentlyBoughtTogether<TObject>({
+  experimental,
+  ...props
+}: FrequentlyBoughtTogetherProps<TObject, HTMLTemplate> & EnvironmentProps) {
+  return render(props);
+}

--- a/packages/recommend-js/src/experimental-personalization/index.ts
+++ b/packages/recommend-js/src/experimental-personalization/index.ts
@@ -1,0 +1,4 @@
+export * from './frequentlyBoughtTogether';
+export * from './relatedProducts';
+export * from './lookingSimilar';
+export * from './trendingItems';

--- a/packages/recommend-js/src/experimental-personalization/lookingSimilar.tsx
+++ b/packages/recommend-js/src/experimental-personalization/lookingSimilar.tsx
@@ -1,20 +1,25 @@
 /** @jsxRuntime classic */
 /** @jsx h */
-import { GetLookingSimilarProps } from '@algolia/recommend-core';
-import { LookingSimilarProps as LookingSimilarVDOMProps } from '@algolia/recommend-vdom';
-
-import { lookingSimilar as render } from '../lookingSimilar';
+import {
+  LookingSimilarProps,
+  lookingSimilar as render,
+} from '../lookingSimilar';
 import { EnvironmentProps, HTMLTemplate } from '../types';
 
-type LookingSimilarProps<
-  TObject,
-  TComponentProps extends Record<string, unknown> = {}
-> = GetLookingSimilarProps<TObject> &
-  Omit<LookingSimilarVDOMProps<TObject, TComponentProps>, 'items' | 'status'>;
+import { Personalization } from './types';
 
-export function lookingSimilar<TObject>({
-  experimental,
-  ...props
-}: LookingSimilarProps<TObject, HTMLTemplate> & EnvironmentProps) {
-  return render(props);
+type Props<TObject> = LookingSimilarProps<TObject, HTMLTemplate> &
+  EnvironmentProps &
+  Personalization;
+
+export function lookingSimilar<TObject>(props: Props<TObject>) {
+  return render<TObject>({
+    ...props,
+    experimental: {
+      personalization: {
+        userToken: props.userToken,
+        region: props.region,
+      },
+    },
+  });
 }

--- a/packages/recommend-js/src/experimental-personalization/lookingSimilar.tsx
+++ b/packages/recommend-js/src/experimental-personalization/lookingSimilar.tsx
@@ -1,25 +1,17 @@
 /** @jsxRuntime classic */
 /** @jsx h */
+import { Personalization } from '@algolia/recommend-core';
+
 import {
   LookingSimilarProps,
   lookingSimilar as render,
 } from '../lookingSimilar';
 import { EnvironmentProps, HTMLTemplate } from '../types';
 
-import { Personalization } from './types';
-
 type Props<TObject> = LookingSimilarProps<TObject, HTMLTemplate> &
   EnvironmentProps &
   Personalization;
 
 export function lookingSimilar<TObject>(props: Props<TObject>) {
-  return render<TObject>({
-    ...props,
-    experimental: {
-      personalization: {
-        userToken: props.userToken,
-        region: props.region,
-      },
-    },
-  });
+  return render<TObject>(props);
 }

--- a/packages/recommend-js/src/experimental-personalization/lookingSimilar.tsx
+++ b/packages/recommend-js/src/experimental-personalization/lookingSimilar.tsx
@@ -1,0 +1,20 @@
+/** @jsxRuntime classic */
+/** @jsx h */
+import { GetLookingSimilarProps } from '@algolia/recommend-core';
+import { LookingSimilarProps as LookingSimilarVDOMProps } from '@algolia/recommend-vdom';
+
+import { lookingSimilar as render } from '../lookingSimilar';
+import { EnvironmentProps, HTMLTemplate } from '../types';
+
+type LookingSimilarProps<
+  TObject,
+  TComponentProps extends Record<string, unknown> = {}
+> = GetLookingSimilarProps<TObject> &
+  Omit<LookingSimilarVDOMProps<TObject, TComponentProps>, 'items' | 'status'>;
+
+export function lookingSimilar<TObject>({
+  experimental,
+  ...props
+}: LookingSimilarProps<TObject, HTMLTemplate> & EnvironmentProps) {
+  return render(props);
+}

--- a/packages/recommend-js/src/experimental-personalization/relatedProducts.tsx
+++ b/packages/recommend-js/src/experimental-personalization/relatedProducts.tsx
@@ -1,20 +1,26 @@
 /** @jsxRuntime classic */
 /** @jsx h */
-import { GetRelatedProductsProps } from '@algolia/recommend-core';
-import { RelatedProductsProps as RelatedProductsVDOMProps } from '@algolia/recommend-vdom';
 
-import { relatedProducts as render } from '../relatedProducts';
+import {
+  RelatedProductsProps,
+  relatedProducts as render,
+} from '../relatedProducts';
 import { EnvironmentProps, HTMLTemplate } from '../types';
 
-type RelatedProductsProps<
-  TObject,
-  TComponentProps extends Record<string, unknown> = {}
-> = GetRelatedProductsProps<TObject> &
-  Omit<RelatedProductsVDOMProps<TObject, TComponentProps>, 'items' | 'status'>;
+import { Personalization } from './types';
 
-export function relatedProducts<TObject>({
-  experimental,
-  ...props
-}: RelatedProductsProps<TObject, HTMLTemplate> & EnvironmentProps) {
-  return render(props);
+type Props<TObject> = RelatedProductsProps<TObject, HTMLTemplate> &
+  EnvironmentProps &
+  Personalization;
+
+export function relatedProducts<TObject>(props: Props<TObject>) {
+  return render({
+    ...props,
+    experimental: {
+      personalization: {
+        userToken: props.userToken,
+        region: props.region,
+      },
+    },
+  });
 }

--- a/packages/recommend-js/src/experimental-personalization/relatedProducts.tsx
+++ b/packages/recommend-js/src/experimental-personalization/relatedProducts.tsx
@@ -1,26 +1,18 @@
 /** @jsxRuntime classic */
 /** @jsx h */
 
+import { Personalization } from '@algolia/recommend-core';
+
 import {
   RelatedProductsProps,
   relatedProducts as render,
 } from '../relatedProducts';
 import { EnvironmentProps, HTMLTemplate } from '../types';
 
-import { Personalization } from './types';
-
 type Props<TObject> = RelatedProductsProps<TObject, HTMLTemplate> &
   EnvironmentProps &
   Personalization;
 
 export function relatedProducts<TObject>(props: Props<TObject>) {
-  return render({
-    ...props,
-    experimental: {
-      personalization: {
-        userToken: props.userToken,
-        region: props.region,
-      },
-    },
-  });
+  return render<TObject>(props);
 }

--- a/packages/recommend-js/src/experimental-personalization/relatedProducts.tsx
+++ b/packages/recommend-js/src/experimental-personalization/relatedProducts.tsx
@@ -1,0 +1,20 @@
+/** @jsxRuntime classic */
+/** @jsx h */
+import { GetRelatedProductsProps } from '@algolia/recommend-core';
+import { RelatedProductsProps as RelatedProductsVDOMProps } from '@algolia/recommend-vdom';
+
+import { relatedProducts as render } from '../relatedProducts';
+import { EnvironmentProps, HTMLTemplate } from '../types';
+
+type RelatedProductsProps<
+  TObject,
+  TComponentProps extends Record<string, unknown> = {}
+> = GetRelatedProductsProps<TObject> &
+  Omit<RelatedProductsVDOMProps<TObject, TComponentProps>, 'items' | 'status'>;
+
+export function relatedProducts<TObject>({
+  experimental,
+  ...props
+}: RelatedProductsProps<TObject, HTMLTemplate> & EnvironmentProps) {
+  return render(props);
+}

--- a/packages/recommend-js/src/experimental-personalization/trendingItems.tsx
+++ b/packages/recommend-js/src/experimental-personalization/trendingItems.tsx
@@ -1,22 +1,15 @@
 /** @jsxRuntime classic */
 /** @jsx h */
 
+import { Personalization } from '@algolia/recommend-core';
+
 import { TrendingItemsProps, trendingItems as render } from '../trendingItems';
 import { EnvironmentProps, HTMLTemplate } from '../types';
 
-import { Personalization } from './types';
 type Props<TObject> = TrendingItemsProps<TObject, HTMLTemplate> &
   EnvironmentProps &
   Personalization;
 
 export function trendingItems<TObject>({ ...props }: Props<TObject>) {
-  return render({
-    ...props,
-    experimental: {
-      personalization: {
-        userToken: props.userToken,
-        region: props.region,
-      },
-    },
-  });
+  return render<TObject>(props);
 }

--- a/packages/recommend-js/src/experimental-personalization/trendingItems.tsx
+++ b/packages/recommend-js/src/experimental-personalization/trendingItems.tsx
@@ -1,0 +1,20 @@
+/** @jsxRuntime classic */
+/** @jsx h */
+import { GetTrendingItemsProps } from '@algolia/recommend-core';
+import { TrendingItemsProps as TrendingItemsVDOMProps } from '@algolia/recommend-vdom';
+
+import { trendingItems as render } from '../trendingItems';
+import { EnvironmentProps, HTMLTemplate } from '../types';
+
+type TrendingItemsProps<
+  TObject,
+  TComponentProps extends Record<string, unknown> = {}
+> = GetTrendingItemsProps<TObject> &
+  Omit<TrendingItemsVDOMProps<TObject, TComponentProps>, 'items' | 'status'>;
+
+export function trendingItems<TObject>({
+  experimental,
+  ...props
+}: TrendingItemsProps<TObject, HTMLTemplate> & EnvironmentProps) {
+  return render(props);
+}

--- a/packages/recommend-js/src/experimental-personalization/trendingItems.tsx
+++ b/packages/recommend-js/src/experimental-personalization/trendingItems.tsx
@@ -1,20 +1,22 @@
 /** @jsxRuntime classic */
 /** @jsx h */
-import { GetTrendingItemsProps } from '@algolia/recommend-core';
-import { TrendingItemsProps as TrendingItemsVDOMProps } from '@algolia/recommend-vdom';
 
-import { trendingItems as render } from '../trendingItems';
+import { TrendingItemsProps, trendingItems as render } from '../trendingItems';
 import { EnvironmentProps, HTMLTemplate } from '../types';
 
-type TrendingItemsProps<
-  TObject,
-  TComponentProps extends Record<string, unknown> = {}
-> = GetTrendingItemsProps<TObject> &
-  Omit<TrendingItemsVDOMProps<TObject, TComponentProps>, 'items' | 'status'>;
+import { Personalization } from './types';
+type Props<TObject> = TrendingItemsProps<TObject, HTMLTemplate> &
+  EnvironmentProps &
+  Personalization;
 
-export function trendingItems<TObject>({
-  experimental,
-  ...props
-}: TrendingItemsProps<TObject, HTMLTemplate> & EnvironmentProps) {
-  return render(props);
+export function trendingItems<TObject>({ ...props }: Props<TObject>) {
+  return render({
+    ...props,
+    experimental: {
+      personalization: {
+        userToken: props.userToken,
+        region: props.region,
+      },
+    },
+  });
 }

--- a/packages/recommend-js/src/experimental-personalization/types.ts
+++ b/packages/recommend-js/src/experimental-personalization/types.ts
@@ -1,0 +1,3 @@
+import { Experimental } from '@algolia/recommend-core';
+
+export type Personalization = Experimental['personalization'];

--- a/packages/recommend-js/src/experimental-personalization/types.ts
+++ b/packages/recommend-js/src/experimental-personalization/types.ts
@@ -1,3 +1,0 @@
-import { Experimental } from '@algolia/recommend-core';
-
-export type Personalization = Experimental['personalization'];

--- a/packages/recommend-js/src/frequentlyBoughtTogether.tsx
+++ b/packages/recommend-js/src/frequentlyBoughtTogether.tsx
@@ -53,7 +53,7 @@ function useFrequentlyBoughtTogether<TObject>(
 type FrequentlyBoughtTogetherProps<
   TObject,
   TComponentProps extends Record<string, unknown> = {}
-> = GetFrequentlyBoughtTogetherProps<TObject> &
+> = Omit<GetFrequentlyBoughtTogetherProps<TObject>, 'experimental'> &
   Omit<
     FrequentlyBoughtTogetherVDOMProps<TObject, TComponentProps>,
     'items' | 'status'

--- a/packages/recommend-js/src/frequentlyBoughtTogether.tsx
+++ b/packages/recommend-js/src/frequentlyBoughtTogether.tsx
@@ -50,10 +50,10 @@ function useFrequentlyBoughtTogether<TObject>(
   };
 }
 
-type FrequentlyBoughtTogetherProps<
+export type FrequentlyBoughtTogetherProps<
   TObject,
   TComponentProps extends Record<string, unknown> = {}
-> = Omit<GetFrequentlyBoughtTogetherProps<TObject>, 'experimental'> &
+> = Omit<GetFrequentlyBoughtTogetherProps<TObject>, 'userToken' | 'region'> &
   Omit<
     FrequentlyBoughtTogetherVDOMProps<TObject, TComponentProps>,
     'items' | 'status'

--- a/packages/recommend-js/src/lookingSimilar.tsx
+++ b/packages/recommend-js/src/lookingSimilar.tsx
@@ -46,10 +46,10 @@ function useLookingSimilar<TObject>(props: GetLookingSimilarProps<TObject>) {
   };
 }
 
-type LookingSimilarProps<
+export type LookingSimilarProps<
   TObject,
   TComponentProps extends Record<string, unknown> = {}
-> = Omit<GetLookingSimilarProps<TObject>, 'experimental'> &
+> = GetLookingSimilarProps<TObject> &
   Omit<LookingSimilarVDOMProps<TObject, TComponentProps>, 'items' | 'status'>;
 
 function LookingSimilar<

--- a/packages/recommend-js/src/lookingSimilar.tsx
+++ b/packages/recommend-js/src/lookingSimilar.tsx
@@ -49,7 +49,7 @@ function useLookingSimilar<TObject>(props: GetLookingSimilarProps<TObject>) {
 export type LookingSimilarProps<
   TObject,
   TComponentProps extends Record<string, unknown> = {}
-> = GetLookingSimilarProps<TObject> &
+> = Omit<GetLookingSimilarProps<TObject>, 'userToken' | 'region'> &
   Omit<LookingSimilarVDOMProps<TObject, TComponentProps>, 'items' | 'status'>;
 
 function LookingSimilar<

--- a/packages/recommend-js/src/lookingSimilar.tsx
+++ b/packages/recommend-js/src/lookingSimilar.tsx
@@ -49,7 +49,7 @@ function useLookingSimilar<TObject>(props: GetLookingSimilarProps<TObject>) {
 type LookingSimilarProps<
   TObject,
   TComponentProps extends Record<string, unknown> = {}
-> = GetLookingSimilarProps<TObject> &
+> = Omit<GetLookingSimilarProps<TObject>, 'experimental'> &
   Omit<LookingSimilarVDOMProps<TObject, TComponentProps>, 'items' | 'status'>;
 
 function LookingSimilar<

--- a/packages/recommend-js/src/relatedProducts.tsx
+++ b/packages/recommend-js/src/relatedProducts.tsx
@@ -49,7 +49,7 @@ function useRelatedProducts<TObject>(props: GetRelatedProductsProps<TObject>) {
 type RelatedProductsProps<
   TObject,
   TComponentProps extends Record<string, unknown> = {}
-> = GetRelatedProductsProps<TObject> &
+> = Omit<GetRelatedProductsProps<TObject>, 'experimental'> &
   Omit<RelatedProductsVDOMProps<TObject, TComponentProps>, 'items' | 'status'>;
 
 function RelatedProducts<

--- a/packages/recommend-js/src/relatedProducts.tsx
+++ b/packages/recommend-js/src/relatedProducts.tsx
@@ -46,10 +46,10 @@ function useRelatedProducts<TObject>(props: GetRelatedProductsProps<TObject>) {
   };
 }
 
-type RelatedProductsProps<
+export type RelatedProductsProps<
   TObject,
   TComponentProps extends Record<string, unknown> = {}
-> = Omit<GetRelatedProductsProps<TObject>, 'experimental'> &
+> = Omit<GetRelatedProductsProps<TObject>, 'userToken' | 'region'> &
   Omit<RelatedProductsVDOMProps<TObject, TComponentProps>, 'items' | 'status'>;
 
 function RelatedProducts<

--- a/packages/recommend-js/src/trendingItems.tsx
+++ b/packages/recommend-js/src/trendingItems.tsx
@@ -49,7 +49,7 @@ function useTrendingItems<TObject>(props: GetTrendingItemsProps<TObject>) {
 type TrendingItemsProps<
   TObject,
   TComponentProps extends Record<string, unknown> = {}
-> = GetTrendingItemsProps<TObject> &
+> = Omit<GetTrendingItemsProps<TObject>, 'experimental'> &
   Omit<TrendingItemsVDOMProps<TObject, TComponentProps>, 'items' | 'status'>;
 
 function TrendingItems<

--- a/packages/recommend-js/src/trendingItems.tsx
+++ b/packages/recommend-js/src/trendingItems.tsx
@@ -46,10 +46,10 @@ function useTrendingItems<TObject>(props: GetTrendingItemsProps<TObject>) {
   };
 }
 
-type TrendingItemsProps<
+export type TrendingItemsProps<
   TObject,
   TComponentProps extends Record<string, unknown> = {}
-> = Omit<GetTrendingItemsProps<TObject>, 'experimental'> &
+> = Omit<GetTrendingItemsProps<TObject>, 'userToken' | 'region'> &
   Omit<TrendingItemsVDOMProps<TObject, TComponentProps>, 'items' | 'status'>;
 
 function TrendingItems<

--- a/packages/recommend-react/package.json
+++ b/packages/recommend-react/package.json
@@ -9,7 +9,9 @@
     "name": "Algolia, Inc.",
     "url": "https://www.algolia.com"
   },
-  "source": "src/index.ts",
+  "source": {
+    "main": "src/index.ts"
+  },
   "types": "dist/esm/index.d.ts",
   "module": "dist/esm/index.js",
   "main": "dist/umd/index.js",

--- a/packages/recommend-react/package.json
+++ b/packages/recommend-react/package.json
@@ -9,9 +9,7 @@
     "name": "Algolia, Inc.",
     "url": "https://www.algolia.com"
   },
-  "source": {
-    "main": "src/index.ts"
-  },
+  "source":  "src/index.ts",
   "types": "dist/esm/index.d.ts",
   "module": "dist/esm/index.js",
   "main": "dist/umd/index.js",

--- a/packages/recommend-react/package.json
+++ b/packages/recommend-react/package.json
@@ -9,7 +9,7 @@
     "name": "Algolia, Inc.",
     "url": "https://www.algolia.com"
   },
-  "source":  "src/index.ts",
+  "source": "src/index.ts",
   "types": "dist/esm/index.d.ts",
   "module": "dist/esm/index.js",
   "main": "dist/umd/index.js",

--- a/packages/recommend-react/src/FrequentlyBoughtTogether.tsx
+++ b/packages/recommend-react/src/FrequentlyBoughtTogether.tsx
@@ -16,7 +16,7 @@ const UncontrolledFrequentlyBoughtTogether = createFrequentlyBoughtTogetherCompo
 );
 
 export type UseFrequentlyBoughtTogetherProps<TObject> = OptionalRecommendClient<
-  GetFrequentlyBoughtTogetherProps<TObject>
+  Omit<GetFrequentlyBoughtTogetherProps<TObject>, 'userToken' | 'region'>
 >;
 
 export type FrequentlyBoughtTogetherProps<
@@ -33,8 +33,6 @@ export function FrequentlyBoughtTogether<TObject>(
   const { recommendations, status } = useFrequentlyBoughtTogether<TObject>(
     props
   );
-
-  console.log('recommendations', recommendations);
 
   return (
     <UncontrolledFrequentlyBoughtTogether

--- a/packages/recommend-react/src/FrequentlyBoughtTogether.tsx
+++ b/packages/recommend-react/src/FrequentlyBoughtTogether.tsx
@@ -15,8 +15,9 @@ const UncontrolledFrequentlyBoughtTogether = createFrequentlyBoughtTogetherCompo
   }
 );
 
-export type UseFrequentlyBoughtTogetherProps<TObject> = OptionalRecommendClient<
-  GetFrequentlyBoughtTogetherProps<TObject>
+export type UseFrequentlyBoughtTogetherProps<TObject> = Omit<
+  OptionalRecommendClient<GetFrequentlyBoughtTogetherProps<TObject>>,
+  'experimental'
 >;
 
 export type FrequentlyBoughtTogetherProps<

--- a/packages/recommend-react/src/FrequentlyBoughtTogether.tsx
+++ b/packages/recommend-react/src/FrequentlyBoughtTogether.tsx
@@ -15,9 +15,8 @@ const UncontrolledFrequentlyBoughtTogether = createFrequentlyBoughtTogetherCompo
   }
 );
 
-export type UseFrequentlyBoughtTogetherProps<TObject> = Omit<
-  OptionalRecommendClient<GetFrequentlyBoughtTogetherProps<TObject>>,
-  'experimental'
+export type UseFrequentlyBoughtTogetherProps<TObject> = OptionalRecommendClient<
+  GetFrequentlyBoughtTogetherProps<TObject>
 >;
 
 export type FrequentlyBoughtTogetherProps<
@@ -34,6 +33,8 @@ export function FrequentlyBoughtTogether<TObject>(
   const { recommendations, status } = useFrequentlyBoughtTogether<TObject>(
     props
   );
+
+  console.log('recommendations', recommendations);
 
   return (
     <UncontrolledFrequentlyBoughtTogether

--- a/packages/recommend-react/src/LookingSimilar.tsx
+++ b/packages/recommend-react/src/LookingSimilar.tsx
@@ -13,8 +13,9 @@ const UncontrolledLookingSimilar = createLookingSimilarComponent({
   Fragment,
 });
 
-export type UseLookingSimilarProps<TObject> = OptionalRecommendClient<
-  GetLookingSimilarProps<TObject>
+export type UseLookingSimilarProps<TObject> = Omit<
+  OptionalRecommendClient<GetLookingSimilarProps<TObject>>,
+  'experimental'
 >;
 
 export type LookingSimilarProps<TObject> = UseLookingSimilarProps<TObject> &

--- a/packages/recommend-react/src/LookingSimilar.tsx
+++ b/packages/recommend-react/src/LookingSimilar.tsx
@@ -14,7 +14,9 @@ const UncontrolledLookingSimilar = createLookingSimilarComponent({
 });
 
 export type UseLookingSimilarProps<TObject> = Omit<
-  OptionalRecommendClient<GetLookingSimilarProps<TObject>>,
+  OptionalRecommendClient<
+    Omit<GetLookingSimilarProps<TObject>, 'userToken' | 'region'>
+  >,
   'experimental'
 >;
 

--- a/packages/recommend-react/src/Recommend.tsx
+++ b/packages/recommend-react/src/Recommend.tsx
@@ -104,8 +104,8 @@ const reducer: React.Reducer<StateType<unknown>, Action<any>> = (
 export function Recommend<TObject>({
   recommendClient,
   children,
-  experimental,
-}: RecommendProps) {
+  ...props
+}: Omit<RecommendProps, 'experimental'>) {
   const [state, dispatch] = React.useReducer(reducer, {
     isDirty: null,
     cache: {},
@@ -136,7 +136,7 @@ export function Recommend<TObject>({
       recommendClient,
       queries,
       keys,
-      experimental,
+      ...props,
     }).then((result) => {
       Object.entries(result).forEach(([key, value]) => {
         state.widgets.forEach((widget) => {
@@ -155,7 +155,7 @@ export function Recommend<TObject>({
     state.widgets,
     state.cache,
     recommendClient,
-    experimental,
+    props,
   ]);
 
   const register = React.useCallback(

--- a/packages/recommend-react/src/RecommendContext.tsx
+++ b/packages/recommend-react/src/RecommendContext.tsx
@@ -1,9 +1,5 @@
 import { RecommendClient } from '@algolia/recommend';
-import {
-  BatchKeyPair,
-  BatchQuery,
-  Experimental,
-} from '@algolia/recommend-core';
+import { BatchKeyPair, BatchQuery } from '@algolia/recommend-core';
 import React from 'react';
 
 export type GetParametersResult<TObject> = {
@@ -28,10 +24,6 @@ type RecommendContextType<TResult> = {
 export type RecommendProps = {
   children: React.ReactNode;
   recommendClient: RecommendClient;
-  /**
-   * Experimental features not covered by SLA and semantic versioning conventions.
-   */
-  experimental?: Experimental;
 };
 
 export const RecommendContext = React.createContext<RecommendContextType<any>>({

--- a/packages/recommend-react/src/RecommendedForYou.tsx
+++ b/packages/recommend-react/src/RecommendedForYou.tsx
@@ -13,8 +13,9 @@ const UncontrolledRecommendedForYou = createRecommendedForYouComponent({
   Fragment,
 });
 
-export type UseRecommendedForYouProps<TObject> = OptionalRecommendClient<
-  GetRecommendedForYouProps<TObject>
+export type UseRecommendedForYouProps<TObject> = Omit<
+  OptionalRecommendClient<GetRecommendedForYouProps<TObject>>,
+  'experimental'
 >;
 
 export type RecommendedForYouProps<

--- a/packages/recommend-react/src/RelatedProducts.tsx
+++ b/packages/recommend-react/src/RelatedProducts.tsx
@@ -13,8 +13,9 @@ const UncontrolledRelatedProducts = createRelatedProductsComponent({
   Fragment,
 });
 
-export type UseRelatedProductsProps<TObject> = OptionalRecommendClient<
-  GetRelatedProductsProps<TObject>
+export type UseRelatedProductsProps<TObject> = Omit<
+  OptionalRecommendClient<GetRelatedProductsProps<TObject>>,
+  'experimental'
 >;
 
 export type RelatedProductsProps<TObject> = UseRelatedProductsProps<TObject> &

--- a/packages/recommend-react/src/RelatedProducts.tsx
+++ b/packages/recommend-react/src/RelatedProducts.tsx
@@ -14,7 +14,9 @@ const UncontrolledRelatedProducts = createRelatedProductsComponent({
 });
 
 export type UseRelatedProductsProps<TObject> = Omit<
-  OptionalRecommendClient<GetRelatedProductsProps<TObject>>,
+  OptionalRecommendClient<
+    Omit<GetRelatedProductsProps<TObject>, 'userToken' | 'region'>
+  >,
   'experimental'
 >;
 

--- a/packages/recommend-react/src/TrendingItems.tsx
+++ b/packages/recommend-react/src/TrendingItems.tsx
@@ -14,7 +14,9 @@ const UncontrolledTrendingItems = createTrendingItemsComponent({
 });
 
 export type UseTrendingItemsProps<TObject> = Omit<
-  OptionalRecommendClient<GetTrendingItemsProps<TObject>>,
+  OptionalRecommendClient<
+    Omit<GetTrendingItemsProps<TObject>, 'userToken' | 'region'>
+  >,
   'experimental'
 >;
 

--- a/packages/recommend-react/src/TrendingItems.tsx
+++ b/packages/recommend-react/src/TrendingItems.tsx
@@ -13,8 +13,9 @@ const UncontrolledTrendingItems = createTrendingItemsComponent({
   Fragment,
 });
 
-export type UseTrendingItemsProps<TObject> = OptionalRecommendClient<
-  GetTrendingItemsProps<TObject>
+export type UseTrendingItemsProps<TObject> = Omit<
+  OptionalRecommendClient<GetTrendingItemsProps<TObject>>,
+  'experimental'
 >;
 
 export type TrendingItemsProps<TObject> = UseTrendingItemsProps<TObject> &

--- a/packages/recommend-react/src/experimental-personalization/FrequentlyBoughtTogether.tsx
+++ b/packages/recommend-react/src/experimental-personalization/FrequentlyBoughtTogether.tsx
@@ -1,11 +1,10 @@
+import { Personalization } from '@algolia/recommend-core';
 import React from 'react';
 
 import {
   FrequentlyBoughtTogetherProps,
   FrequentlyBoughtTogether as Component,
 } from '../FrequentlyBoughtTogether';
-
-import { Personalization } from './types';
 
 type Props<TObject> = FrequentlyBoughtTogetherProps<TObject> & Personalization;
 

--- a/packages/recommend-react/src/experimental-personalization/FrequentlyBoughtTogether.tsx
+++ b/packages/recommend-react/src/experimental-personalization/FrequentlyBoughtTogether.tsx
@@ -1,17 +1,14 @@
-import { Experimental } from '@algolia/recommend-core';
+import React from 'react';
 
 import {
   FrequentlyBoughtTogetherProps,
-  FrequentlyBoughtTogether as render,
+  FrequentlyBoughtTogether as Component,
 } from '../FrequentlyBoughtTogether';
 
-type Props<TObject> = FrequentlyBoughtTogetherProps<TObject> & {
-  /**
-   * Experimental features not covered by SLA and semantic versioning conventions.
-   */
-  experimental?: Experimental;
-};
+import { Personalization } from './types';
+
+type Props<TObject> = FrequentlyBoughtTogetherProps<TObject> & Personalization;
 
 export function FrequentlyBoughtTogether<TObject>(props: Props<TObject>) {
-  return render(props);
+  return <Component {...props} />;
 }

--- a/packages/recommend-react/src/experimental-personalization/FrequentlyBoughtTogether.tsx
+++ b/packages/recommend-react/src/experimental-personalization/FrequentlyBoughtTogether.tsx
@@ -1,0 +1,17 @@
+import { Experimental } from '@algolia/recommend-core';
+
+import {
+  FrequentlyBoughtTogetherProps,
+  FrequentlyBoughtTogether as render,
+} from '../FrequentlyBoughtTogether';
+
+type Props<TObject> = FrequentlyBoughtTogetherProps<TObject> & {
+  /**
+   * Experimental features not covered by SLA and semantic versioning conventions.
+   */
+  experimental?: Experimental;
+};
+
+export function FrequentlyBoughtTogether<TObject>(props: Props<TObject>) {
+  return render(props);
+}

--- a/packages/recommend-react/src/experimental-personalization/LookingSimilar.tsx
+++ b/packages/recommend-react/src/experimental-personalization/LookingSimilar.tsx
@@ -1,0 +1,17 @@
+import { Experimental } from '@algolia/recommend-core';
+
+import {
+  LookingSimilarProps,
+  LookingSimilar as render,
+} from '../LookingSimilar';
+
+type Props<TObject> = LookingSimilarProps<TObject> & {
+  /**
+   * Experimental features not covered by SLA and semantic versioning conventions.
+   */
+  experimental?: Experimental;
+};
+
+export function LookingSimilar<TObject>(props: Props<TObject>) {
+  return render(props);
+}

--- a/packages/recommend-react/src/experimental-personalization/LookingSimilar.tsx
+++ b/packages/recommend-react/src/experimental-personalization/LookingSimilar.tsx
@@ -1,4 +1,4 @@
-import { Experimental } from '@algolia/recommend-core';
+import { Personalization } from '@algolia/recommend-core';
 import React from 'react';
 
 import {
@@ -6,12 +6,7 @@ import {
   LookingSimilar as Component,
 } from '../LookingSimilar';
 
-type Props<TObject> = LookingSimilarProps<TObject> & {
-  /**
-   * Experimental features not covered by SLA and semantic versioning conventions.
-   */
-  experimental?: Experimental;
-};
+type Props<TObject> = LookingSimilarProps<TObject> & Personalization;
 
 export function LookingSimilar<TObject>(props: Props<TObject>) {
   return <Component {...props} />;

--- a/packages/recommend-react/src/experimental-personalization/LookingSimilar.tsx
+++ b/packages/recommend-react/src/experimental-personalization/LookingSimilar.tsx
@@ -1,8 +1,9 @@
 import { Experimental } from '@algolia/recommend-core';
+import React from 'react';
 
 import {
   LookingSimilarProps,
-  LookingSimilar as render,
+  LookingSimilar as Component,
 } from '../LookingSimilar';
 
 type Props<TObject> = LookingSimilarProps<TObject> & {
@@ -13,5 +14,5 @@ type Props<TObject> = LookingSimilarProps<TObject> & {
 };
 
 export function LookingSimilar<TObject>(props: Props<TObject>) {
-  return render(props);
+  return <Component {...props} />;
 }

--- a/packages/recommend-react/src/experimental-personalization/Recommend.tsx
+++ b/packages/recommend-react/src/experimental-personalization/Recommend.tsx
@@ -1,15 +1,10 @@
-import { Experimental } from '@algolia/recommend-core';
+import { Personalization } from '@algolia/recommend-core';
 import React from 'react';
 
 import { Recommend as ContextProvider } from '../Recommend';
 import { RecommendProps } from '../RecommendContext';
 
-type Props = RecommendProps & {
-  /**
-   * Experimental features not covered by SLA and semantic versioning conventions.
-   */
-  experimental?: Experimental;
-};
+type Props = RecommendProps & Personalization;
 
 export function Recommend<TObject>({ recommendClient, children }: Props) {
   return (

--- a/packages/recommend-react/src/experimental-personalization/Recommend.tsx
+++ b/packages/recommend-react/src/experimental-personalization/Recommend.tsx
@@ -1,0 +1,20 @@
+import { Experimental } from '@algolia/recommend-core';
+import React from 'react';
+
+import { Recommend as ContextProvider } from '../Recommend';
+import { RecommendProps } from '../RecommendContext';
+
+type Props = RecommendProps & {
+  /**
+   * Experimental features not covered by SLA and semantic versioning conventions.
+   */
+  experimental?: Experimental;
+};
+
+export function Recommend<TObject>({ recommendClient, children }: Props) {
+  return (
+    <ContextProvider<TObject> recommendClient={recommendClient}>
+      {children}
+    </ContextProvider>
+  );
+}

--- a/packages/recommend-react/src/experimental-personalization/RelatedProducts.tsx
+++ b/packages/recommend-react/src/experimental-personalization/RelatedProducts.tsx
@@ -1,0 +1,17 @@
+import { Experimental } from '@algolia/recommend-core';
+
+import {
+  RelatedProductsProps,
+  RelatedProducts as render,
+} from '../RelatedProducts';
+
+type Props<TObject> = RelatedProductsProps<TObject> & {
+  /**
+   * Experimental features not covered by SLA and semantic versioning conventions.
+   */
+  experimental?: Experimental;
+};
+
+export function RelatedProducts<TObject>(props: Props<TObject>) {
+  return render(props);
+}

--- a/packages/recommend-react/src/experimental-personalization/RelatedProducts.tsx
+++ b/packages/recommend-react/src/experimental-personalization/RelatedProducts.tsx
@@ -1,8 +1,9 @@
 import { Experimental } from '@algolia/recommend-core';
+import React from 'react';
 
 import {
   RelatedProductsProps,
-  RelatedProducts as render,
+  RelatedProducts as Component,
 } from '../RelatedProducts';
 
 type Props<TObject> = RelatedProductsProps<TObject> & {
@@ -13,5 +14,5 @@ type Props<TObject> = RelatedProductsProps<TObject> & {
 };
 
 export function RelatedProducts<TObject>(props: Props<TObject>) {
-  return render(props);
+  return <Component {...props} />;
 }

--- a/packages/recommend-react/src/experimental-personalization/RelatedProducts.tsx
+++ b/packages/recommend-react/src/experimental-personalization/RelatedProducts.tsx
@@ -1,4 +1,4 @@
-import { Experimental } from '@algolia/recommend-core';
+import { Personalization } from '@algolia/recommend-core';
 import React from 'react';
 
 import {
@@ -6,12 +6,7 @@ import {
   RelatedProducts as Component,
 } from '../RelatedProducts';
 
-type Props<TObject> = RelatedProductsProps<TObject> & {
-  /**
-   * Experimental features not covered by SLA and semantic versioning conventions.
-   */
-  experimental?: Experimental;
-};
+type Props<TObject> = RelatedProductsProps<TObject> & Personalization;
 
 export function RelatedProducts<TObject>(props: Props<TObject>) {
   return <Component {...props} />;

--- a/packages/recommend-react/src/experimental-personalization/TrendingItems.tsx
+++ b/packages/recommend-react/src/experimental-personalization/TrendingItems.tsx
@@ -1,5 +1,5 @@
 import { createTrendingItemsComponent } from '@algolia/recommend-vdom';
-import React, { createElement, Fragment, memo } from 'react';
+import React, { createElement, Fragment } from 'react';
 
 import { TrendingItemsProps } from '../TrendingItems';
 
@@ -13,9 +13,8 @@ const UncontrolledTrendingItems = createTrendingItemsComponent({
 
 type Props<TObject> = TrendingItemsProps<TObject> & Personalization;
 
-export const TrendingItems = memo(function TrendingItems<TObject>(
-  props: Props<TObject>
-) {
+export function TrendingItems<TObject>(props: Props<TObject>) {
+  console.log('TrendingItems', props);
   const { recommendations, status } = useTrendingItems<TObject>(props);
 
   return (
@@ -25,4 +24,4 @@ export const TrendingItems = memo(function TrendingItems<TObject>(
       status={status}
     />
   );
-});
+}

--- a/packages/recommend-react/src/experimental-personalization/TrendingItems.tsx
+++ b/packages/recommend-react/src/experimental-personalization/TrendingItems.tsx
@@ -1,27 +1,14 @@
-import { createTrendingItemsComponent } from '@algolia/recommend-vdom';
-import React, { createElement, Fragment } from 'react';
+import React from 'react';
 
-import { TrendingItemsProps } from '../TrendingItems';
+import {
+  TrendingItemsProps,
+  TrendingItems as Component,
+} from '../TrendingItems';
 
 import { Personalization } from './types';
-import { useTrendingItems } from './useTrendingItems';
-
-const UncontrolledTrendingItems = createTrendingItemsComponent({
-  createElement,
-  Fragment,
-});
 
 type Props<TObject> = TrendingItemsProps<TObject> & Personalization;
 
 export function TrendingItems<TObject>(props: Props<TObject>) {
-  console.log('TrendingItems', props);
-  const { recommendations, status } = useTrendingItems<TObject>(props);
-
-  return (
-    <UncontrolledTrendingItems
-      {...props}
-      items={recommendations}
-      status={status}
-    />
-  );
+  return <Component {...props} />;
 }

--- a/packages/recommend-react/src/experimental-personalization/TrendingItems.tsx
+++ b/packages/recommend-react/src/experimental-personalization/TrendingItems.tsx
@@ -1,14 +1,28 @@
-import { Experimental } from '@algolia/recommend-core';
+import { createTrendingItemsComponent } from '@algolia/recommend-vdom';
+import React, { createElement, Fragment, memo } from 'react';
 
-import { TrendingItemsProps, TrendingItems as render } from '../TrendingItems';
+import { TrendingItemsProps } from '../TrendingItems';
 
-type Props<TObject> = TrendingItemsProps<TObject> & {
-  /**
-   * Experimental features not covered by SLA and semantic versioning conventions.
-   */
-  experimental?: Experimental;
-};
+import { Personalization } from './types';
+import { useTrendingItems } from './useTrendingItems';
 
-export function TrendingItems<TObject>(props: Props<TObject>) {
-  return render(props);
-}
+const UncontrolledTrendingItems = createTrendingItemsComponent({
+  createElement,
+  Fragment,
+});
+
+type Props<TObject> = TrendingItemsProps<TObject> & Personalization;
+
+export const TrendingItems = memo(function TrendingItems<TObject>(
+  props: Props<TObject>
+) {
+  const { recommendations, status } = useTrendingItems<TObject>(props);
+
+  return (
+    <UncontrolledTrendingItems
+      {...props}
+      items={recommendations}
+      status={status}
+    />
+  );
+});

--- a/packages/recommend-react/src/experimental-personalization/TrendingItems.tsx
+++ b/packages/recommend-react/src/experimental-personalization/TrendingItems.tsx
@@ -9,5 +9,6 @@ import {
 type Props<TObject> = TrendingItemsProps<TObject> & Personalization;
 
 export function TrendingItems<TObject>(props: Props<TObject>) {
-  return <Component {...props} />;
+  const param = React.useRef(props);
+  return <Component {...param.current} />;
 }

--- a/packages/recommend-react/src/experimental-personalization/TrendingItems.tsx
+++ b/packages/recommend-react/src/experimental-personalization/TrendingItems.tsx
@@ -1,0 +1,14 @@
+import { Experimental } from '@algolia/recommend-core';
+
+import { TrendingItemsProps, TrendingItems as render } from '../TrendingItems';
+
+type Props<TObject> = TrendingItemsProps<TObject> & {
+  /**
+   * Experimental features not covered by SLA and semantic versioning conventions.
+   */
+  experimental?: Experimental;
+};
+
+export function TrendingItems<TObject>(props: Props<TObject>) {
+  return render(props);
+}

--- a/packages/recommend-react/src/experimental-personalization/TrendingItems.tsx
+++ b/packages/recommend-react/src/experimental-personalization/TrendingItems.tsx
@@ -1,11 +1,10 @@
+import { Personalization } from '@algolia/recommend-core';
 import React from 'react';
 
 import {
   TrendingItemsProps,
   TrendingItems as Component,
 } from '../TrendingItems';
-
-import { Personalization } from './types';
 
 type Props<TObject> = TrendingItemsProps<TObject> & Personalization;
 

--- a/packages/recommend-react/src/experimental-personalization/index.ts
+++ b/packages/recommend-react/src/experimental-personalization/index.ts
@@ -1,0 +1,3 @@
+export function todo() {
+  return 'todo';
+}

--- a/packages/recommend-react/src/experimental-personalization/index.ts
+++ b/packages/recommend-react/src/experimental-personalization/index.ts
@@ -8,3 +8,9 @@ export * from './useRelatedProducts';
 export * from './useLookingSimilar';
 export * from './useTrendingItems';
 export * from './Recommend';
+
+// unmodified exports
+export * from '../RecommendedForYou';
+export * from '../TrendingFacets';
+export * from '../useRecommendedForYou';
+export * from '../useTrendingFacets';

--- a/packages/recommend-react/src/experimental-personalization/index.ts
+++ b/packages/recommend-react/src/experimental-personalization/index.ts
@@ -1,3 +1,10 @@
-export function todo() {
-  return 'todo';
-}
+export * from './FrequentlyBoughtTogether';
+export * from './RelatedProducts';
+export * from './LookingSimilar';
+export * from './TrendingItems';
+export * from './useFrequentlyBoughtTogether';
+export * from './useRecommendations';
+export * from './useRelatedProducts';
+export * from './useLookingSimilar';
+export * from './useTrendingItems';
+export * from './Recommend';

--- a/packages/recommend-react/src/experimental-personalization/types.ts
+++ b/packages/recommend-react/src/experimental-personalization/types.ts
@@ -1,0 +1,3 @@
+import { Experimental } from '@algolia/recommend-core';
+
+export type Personalization = Experimental['personalization'];

--- a/packages/recommend-react/src/experimental-personalization/types.ts
+++ b/packages/recommend-react/src/experimental-personalization/types.ts
@@ -1,3 +1,0 @@
-import { Experimental } from '@algolia/recommend-core';
-
-export type Personalization = Experimental['personalization'];

--- a/packages/recommend-react/src/experimental-personalization/useFrequentlyBoughtTogether.ts
+++ b/packages/recommend-react/src/experimental-personalization/useFrequentlyBoughtTogether.ts
@@ -1,0 +1,15 @@
+import { Experimental } from '@algolia/recommend-core';
+
+import { UseFrequentlyBoughtTogetherProps } from '../FrequentlyBoughtTogether';
+import { useFrequentlyBoughtTogether as hook } from '../useFrequentlyBoughtTogether';
+
+type Props<TObject> = UseFrequentlyBoughtTogetherProps<TObject> & {
+  /**
+   * Experimental features not covered by SLA and semantic versioning conventions.
+   */
+  experimental?: Experimental;
+};
+
+export function useFrequentlyBoughtTogether<TObject>(props: Props<TObject>) {
+  return hook(props);
+}

--- a/packages/recommend-react/src/experimental-personalization/useFrequentlyBoughtTogether.ts
+++ b/packages/recommend-react/src/experimental-personalization/useFrequentlyBoughtTogether.ts
@@ -1,15 +1,11 @@
-import { Experimental } from '@algolia/recommend-core';
-
 import { UseFrequentlyBoughtTogetherProps } from '../FrequentlyBoughtTogether';
-import { useFrequentlyBoughtTogether as hook } from '../useFrequentlyBoughtTogether';
+import { useFrequentlyBoughtTogether as useHook } from '../useFrequentlyBoughtTogether';
 
-type Props<TObject> = UseFrequentlyBoughtTogetherProps<TObject> & {
-  /**
-   * Experimental features not covered by SLA and semantic versioning conventions.
-   */
-  experimental?: Experimental;
-};
+import { Personalization } from './types';
+
+type Props<TObject> = UseFrequentlyBoughtTogetherProps<TObject> &
+  Personalization;
 
 export function useFrequentlyBoughtTogether<TObject>(props: Props<TObject>) {
-  return hook(props);
+  return useHook(props);
 }

--- a/packages/recommend-react/src/experimental-personalization/useFrequentlyBoughtTogether.ts
+++ b/packages/recommend-react/src/experimental-personalization/useFrequentlyBoughtTogether.ts
@@ -1,7 +1,7 @@
+import { Personalization } from '@algolia/recommend-core';
+
 import { UseFrequentlyBoughtTogetherProps } from '../FrequentlyBoughtTogether';
 import { useFrequentlyBoughtTogether as useHook } from '../useFrequentlyBoughtTogether';
-
-import { Personalization } from './types';
 
 type Props<TObject> = UseFrequentlyBoughtTogetherProps<TObject> &
   Personalization;

--- a/packages/recommend-react/src/experimental-personalization/useLookingSimilar.ts
+++ b/packages/recommend-react/src/experimental-personalization/useLookingSimilar.ts
@@ -1,0 +1,15 @@
+import { Experimental } from '@algolia/recommend-core';
+
+import { UseLookingSimilarProps } from '../LookingSimilar';
+import { useLookingSimilar as hook } from '../useLookingSimilar';
+
+type Props<TObject> = UseLookingSimilarProps<TObject> & {
+  /**
+   * Experimental features not covered by SLA and semantic versioning conventions.
+   */
+  experimental?: Experimental;
+};
+
+export function useLookingSimilar<TObject>(props: Props<TObject>) {
+  return hook(props);
+}

--- a/packages/recommend-react/src/experimental-personalization/useLookingSimilar.ts
+++ b/packages/recommend-react/src/experimental-personalization/useLookingSimilar.ts
@@ -1,15 +1,10 @@
-import { Experimental } from '@algolia/recommend-core';
-
 import { UseLookingSimilarProps } from '../LookingSimilar';
-import { useLookingSimilar as hook } from '../useLookingSimilar';
+import { useLookingSimilar as useHook } from '../useLookingSimilar';
 
-type Props<TObject> = UseLookingSimilarProps<TObject> & {
-  /**
-   * Experimental features not covered by SLA and semantic versioning conventions.
-   */
-  experimental?: Experimental;
-};
+import { Personalization } from './types';
+
+type Props<TObject> = UseLookingSimilarProps<TObject> & Personalization;
 
 export function useLookingSimilar<TObject>(props: Props<TObject>) {
-  return hook(props);
+  return useHook(props);
 }

--- a/packages/recommend-react/src/experimental-personalization/useLookingSimilar.ts
+++ b/packages/recommend-react/src/experimental-personalization/useLookingSimilar.ts
@@ -1,7 +1,7 @@
+import { Personalization } from '@algolia/recommend-core';
+
 import { UseLookingSimilarProps } from '../LookingSimilar';
 import { useLookingSimilar as useHook } from '../useLookingSimilar';
-
-import { Personalization } from './types';
 
 type Props<TObject> = UseLookingSimilarProps<TObject> & Personalization;
 

--- a/packages/recommend-react/src/experimental-personalization/useRecommendations.ts
+++ b/packages/recommend-react/src/experimental-personalization/useRecommendations.ts
@@ -1,0 +1,17 @@
+import { Experimental } from '@algolia/recommend-core';
+
+import {
+  UseRecommendationsProps,
+  useRecommendations as hook,
+} from '../useRecommendations';
+
+type Props<TObject> = UseRecommendationsProps<TObject> & {
+  /**
+   * Experimental features not covered by SLA and semantic versioning conventions.
+   */
+  experimental?: Experimental;
+};
+
+export function useRecommendations<TObject>(props: Props<TObject>) {
+  return hook(props);
+}

--- a/packages/recommend-react/src/experimental-personalization/useRecommendations.ts
+++ b/packages/recommend-react/src/experimental-personalization/useRecommendations.ts
@@ -1,17 +1,12 @@
-import { Experimental } from '@algolia/recommend-core';
-
 import {
   UseRecommendationsProps,
-  useRecommendations as hook,
+  useRecommendations as useHook,
 } from '../useRecommendations';
 
-type Props<TObject> = UseRecommendationsProps<TObject> & {
-  /**
-   * Experimental features not covered by SLA and semantic versioning conventions.
-   */
-  experimental?: Experimental;
-};
+import { Personalization } from './types';
+
+type Props<TObject> = UseRecommendationsProps<TObject> & Personalization;
 
 export function useRecommendations<TObject>(props: Props<TObject>) {
-  return hook(props);
+  return useHook(props);
 }

--- a/packages/recommend-react/src/experimental-personalization/useRecommendations.ts
+++ b/packages/recommend-react/src/experimental-personalization/useRecommendations.ts
@@ -1,9 +1,9 @@
+import { Personalization } from '@algolia/recommend-core';
+
 import {
   UseRecommendationsProps,
   useRecommendations as useHook,
 } from '../useRecommendations';
-
-import { Personalization } from './types';
 
 type Props<TObject> = UseRecommendationsProps<TObject> & Personalization;
 

--- a/packages/recommend-react/src/experimental-personalization/useRelatedProducts.ts
+++ b/packages/recommend-react/src/experimental-personalization/useRelatedProducts.ts
@@ -1,7 +1,7 @@
+import { Personalization } from '@algolia/recommend-core';
+
 import { UseRelatedProductsProps } from '../RelatedProducts';
 import { useRelatedProducts as useHook } from '../useRelatedProducts';
-
-import { Personalization } from './types';
 
 type Props<TObject> = UseRelatedProductsProps<TObject> & Personalization;
 

--- a/packages/recommend-react/src/experimental-personalization/useRelatedProducts.ts
+++ b/packages/recommend-react/src/experimental-personalization/useRelatedProducts.ts
@@ -1,0 +1,15 @@
+import { Experimental } from '@algolia/recommend-core';
+
+import { UseRelatedProductsProps } from '../RelatedProducts';
+import { useRelatedProducts as hook } from '../useRelatedProducts';
+
+type Props<TObject> = UseRelatedProductsProps<TObject> & {
+  /**
+   * Experimental features not covered by SLA and semantic versioning conventions.
+   */
+  experimental?: Experimental;
+};
+
+export function useRelatedProducts<TObject>(props: Props<TObject>) {
+  return hook(props);
+}

--- a/packages/recommend-react/src/experimental-personalization/useRelatedProducts.ts
+++ b/packages/recommend-react/src/experimental-personalization/useRelatedProducts.ts
@@ -1,15 +1,10 @@
-import { Experimental } from '@algolia/recommend-core';
-
 import { UseRelatedProductsProps } from '../RelatedProducts';
-import { useRelatedProducts as hook } from '../useRelatedProducts';
+import { useRelatedProducts as useHook } from '../useRelatedProducts';
 
-type Props<TObject> = UseRelatedProductsProps<TObject> & {
-  /**
-   * Experimental features not covered by SLA and semantic versioning conventions.
-   */
-  experimental?: Experimental;
-};
+import { Personalization } from './types';
+
+type Props<TObject> = UseRelatedProductsProps<TObject> & Personalization;
 
 export function useRelatedProducts<TObject>(props: Props<TObject>) {
-  return hook(props);
+  return useHook(props);
 }

--- a/packages/recommend-react/src/experimental-personalization/useTrendingItems.ts
+++ b/packages/recommend-react/src/experimental-personalization/useTrendingItems.ts
@@ -6,7 +6,5 @@ import { Personalization } from './types';
 type Props<TObject> = UseTrendingItemsProps<TObject> & Personalization;
 
 export function useTrendingItems<TObject>(props: Props<TObject>) {
-  const { recommendations, status } = useHook(props);
-  console.log('hook call', status);
-  return { recommendations, status };
+  return useHook(props);
 }

--- a/packages/recommend-react/src/experimental-personalization/useTrendingItems.ts
+++ b/packages/recommend-react/src/experimental-personalization/useTrendingItems.ts
@@ -1,12 +1,12 @@
 import { UseTrendingItemsProps } from '../TrendingItems';
-import { useTrendingItems as hook } from '../useTrendingItems';
+import { useTrendingItems as useHook } from '../useTrendingItems';
 
 import { Personalization } from './types';
 
 type Props<TObject> = UseTrendingItemsProps<TObject> & Personalization;
 
 export function useTrendingItems<TObject>(props: Props<TObject>) {
-  const { recommendations, status } = hook(props);
+  const { recommendations, status } = useHook(props);
   console.log('hook call', status);
   return { recommendations, status };
 }

--- a/packages/recommend-react/src/experimental-personalization/useTrendingItems.ts
+++ b/packages/recommend-react/src/experimental-personalization/useTrendingItems.ts
@@ -1,7 +1,7 @@
+import { Personalization } from '@algolia/recommend-core';
+
 import { UseTrendingItemsProps } from '../TrendingItems';
 import { useTrendingItems as useHook } from '../useTrendingItems';
-
-import { Personalization } from './types';
 
 type Props<TObject> = UseTrendingItemsProps<TObject> & Personalization;
 

--- a/packages/recommend-react/src/experimental-personalization/useTrendingItems.ts
+++ b/packages/recommend-react/src/experimental-personalization/useTrendingItems.ts
@@ -1,0 +1,15 @@
+import { Experimental } from '@algolia/recommend-core';
+
+import { UseTrendingItemsProps } from '../TrendingItems';
+import { useTrendingItems as hook } from '../useTrendingItems';
+
+type Props<TObject> = UseTrendingItemsProps<TObject> & {
+  /**
+   * Experimental features not covered by SLA and semantic versioning conventions.
+   */
+  experimental?: Experimental;
+};
+
+export function useTrendingItems<TObject>(props: Props<TObject>) {
+  return hook(props);
+}

--- a/packages/recommend-react/src/experimental-personalization/useTrendingItems.ts
+++ b/packages/recommend-react/src/experimental-personalization/useTrendingItems.ts
@@ -1,15 +1,11 @@
-import { Experimental } from '@algolia/recommend-core';
-
 import { UseTrendingItemsProps } from '../TrendingItems';
 import { useTrendingItems as hook } from '../useTrendingItems';
 
-type Props<TObject> = UseTrendingItemsProps<TObject> & {
-  /**
-   * Experimental features not covered by SLA and semantic versioning conventions.
-   */
-  experimental?: Experimental;
-};
+import { Personalization } from './types';
+
+type Props<TObject> = UseTrendingItemsProps<TObject> & Personalization;
 
 export function useTrendingItems<TObject>(props: Props<TObject>) {
-  return hook(props);
+  const { recommendations, status } = hook(props);
+  return { recommendations, status };
 }

--- a/packages/recommend-react/src/experimental-personalization/useTrendingItems.ts
+++ b/packages/recommend-react/src/experimental-personalization/useTrendingItems.ts
@@ -7,5 +7,6 @@ type Props<TObject> = UseTrendingItemsProps<TObject> & Personalization;
 
 export function useTrendingItems<TObject>(props: Props<TObject>) {
   const { recommendations, status } = hook(props);
+  console.log('hook call', status);
   return { recommendations, status };
 }

--- a/packages/recommend-react/src/useFrequentlyBoughtTogether.ts
+++ b/packages/recommend-react/src/useFrequentlyBoughtTogether.ts
@@ -21,6 +21,8 @@ export function useFrequentlyBoughtTogether<TObject>({
   transformItems: userTransformItems = (x) => x,
   ...props
 }: UseFrequentlyBoughtTogetherProps<TObject>) {
+  // @ts-expect-error used for internal experimental-personalization
+  const { region, userToken } = props;
   const [result, setResult] = useState<GetRecommendationsResult<TObject>>({
     recommendations: [],
   });
@@ -48,7 +50,6 @@ export function useFrequentlyBoughtTogether<TObject>({
       queryParameters,
       threshold,
       transformItems: transformItemsRef.current,
-      ...props,
     };
 
     if (hasProvider && isContextClient) {
@@ -86,6 +87,8 @@ export function useFrequentlyBoughtTogether<TObject>({
 
     setStatus('loading');
     getFrequentlyBoughtTogether({
+      region,
+      userToken,
       ...param,
       recommendClient: client,
     }).then((response) => {
@@ -104,7 +107,8 @@ export function useFrequentlyBoughtTogether<TObject>({
     hasProvider,
     isContextClient,
     register,
-    props,
+    region,
+    userToken,
   ]);
 
   return {

--- a/packages/recommend-react/src/useFrequentlyBoughtTogether.ts
+++ b/packages/recommend-react/src/useFrequentlyBoughtTogether.ts
@@ -18,8 +18,8 @@ export function useFrequentlyBoughtTogether<TObject>({
   queryParameters: userQueryParameters,
   recommendClient,
   threshold,
-  experimental,
   transformItems: userTransformItems = (x) => x,
+  ...props
 }: UseFrequentlyBoughtTogetherProps<TObject>) {
   const [result, setResult] = useState<GetRecommendationsResult<TObject>>({
     recommendations: [],
@@ -47,8 +47,8 @@ export function useFrequentlyBoughtTogether<TObject>({
       objectIDs,
       queryParameters,
       threshold,
-      experimental,
       transformItems: transformItemsRef.current,
+      ...props,
     };
 
     if (hasProvider && isContextClient) {
@@ -104,7 +104,7 @@ export function useFrequentlyBoughtTogether<TObject>({
     hasProvider,
     isContextClient,
     register,
-    experimental,
+    props,
   ]);
 
   return {

--- a/packages/recommend-react/src/useLookingSimilar.ts
+++ b/packages/recommend-react/src/useLookingSimilar.ts
@@ -22,6 +22,8 @@ export function useLookingSimilar<TObject>({
   transformItems: userTransformItems = (x) => x,
   ...props
 }: UseLookingSimilarProps<TObject>) {
+  // @ts-expect-error used for internal experimental-personalization
+  const { region, userToken } = props;
   const [result, setResult] = useState<GetRecommendationsResult<TObject>>({
     recommendations: [],
   });
@@ -51,7 +53,6 @@ export function useLookingSimilar<TObject>({
       queryParameters,
       threshold,
       transformItems: transformItemsRef.current,
-      ...props,
     };
 
     if (hasProvider && isContextClient) {
@@ -90,6 +91,8 @@ export function useLookingSimilar<TObject>({
 
     setStatus('loading');
     getLookingSimilar({
+      region,
+      userToken,
       ...param,
       recommendClient: client,
     }).then((response) => {
@@ -109,7 +112,8 @@ export function useLookingSimilar<TObject>({
     register,
     setStatus,
     threshold,
-    props,
+    region,
+    userToken,
   ]);
 
   return {

--- a/packages/recommend-react/src/useLookingSimilar.ts
+++ b/packages/recommend-react/src/useLookingSimilar.ts
@@ -20,7 +20,7 @@ export function useLookingSimilar<TObject>({
   recommendClient,
   threshold,
   transformItems: userTransformItems = (x) => x,
-  experimental,
+  ...props
 }: UseLookingSimilarProps<TObject>) {
   const [result, setResult] = useState<GetRecommendationsResult<TObject>>({
     recommendations: [],
@@ -50,8 +50,8 @@ export function useLookingSimilar<TObject>({
       objectIDs,
       queryParameters,
       threshold,
-      experimental,
       transformItems: transformItemsRef.current,
+      ...props,
     };
 
     if (hasProvider && isContextClient) {
@@ -109,7 +109,7 @@ export function useLookingSimilar<TObject>({
     register,
     setStatus,
     threshold,
-    experimental,
+    props,
   ]);
 
   return {

--- a/packages/recommend-react/src/useRecommendations.ts
+++ b/packages/recommend-react/src/useRecommendations.ts
@@ -26,6 +26,7 @@ export function useRecommendations<TObject>({
   transformItems: userTransformItems = (x) => x,
   ...props
 }: UseRecommendationsProps<TObject>) {
+  const { region, userToken } = props;
   const [result, setResult] = useState<GetRecommendationsResult<TObject>>({
     recommendations: [],
   });
@@ -53,7 +54,8 @@ export function useRecommendations<TObject>({
       recommendClient,
       threshold,
       transformItems: transformItemsRef.current,
-      ...props,
+      region,
+      userToken,
     }).then((response) => {
       setResult(response);
       setStatus('idle');
@@ -68,7 +70,8 @@ export function useRecommendations<TObject>({
     recommendClient,
     setStatus,
     threshold,
-    props,
+    region,
+    userToken,
   ]);
 
   return {

--- a/packages/recommend-react/src/useRecommendations.ts
+++ b/packages/recommend-react/src/useRecommendations.ts
@@ -9,7 +9,10 @@ import { useAlgoliaAgent } from './useAlgoliaAgent';
 import { useStableValue } from './useStableValue';
 import { useStatus } from './useStatus';
 
-export type UseRecommendationsProps<TObject> = GetRecommendationsProps<TObject>;
+export type UseRecommendationsProps<TObject> = Omit<
+  GetRecommendationsProps<TObject>,
+  'experimental'
+>;
 
 export function useRecommendations<TObject>({
   fallbackParameters: userFallbackParameters,
@@ -20,8 +23,8 @@ export function useRecommendations<TObject>({
   queryParameters: userQueryParameters,
   recommendClient,
   threshold,
-  experimental,
   transformItems: userTransformItems = (x) => x,
+  ...props
 }: UseRecommendationsProps<TObject>) {
   const [result, setResult] = useState<GetRecommendationsResult<TObject>>({
     recommendations: [],
@@ -49,8 +52,8 @@ export function useRecommendations<TObject>({
       queryParameters,
       recommendClient,
       threshold,
-      experimental,
       transformItems: transformItemsRef.current,
+      ...props,
     }).then((response) => {
       setResult(response);
       setStatus('idle');
@@ -65,7 +68,7 @@ export function useRecommendations<TObject>({
     recommendClient,
     setStatus,
     threshold,
-    experimental,
+    props,
   ]);
 
   return {

--- a/packages/recommend-react/src/useRelatedProducts.ts
+++ b/packages/recommend-react/src/useRelatedProducts.ts
@@ -19,8 +19,8 @@ export function useRelatedProducts<TObject>({
   queryParameters: userQueryParameters,
   recommendClient,
   threshold,
-  experimental,
   transformItems: userTransformItems = (x) => x,
+  ...props
 }: UseRelatedProductsProps<TObject>) {
   const [result, setResult] = useState<GetRecommendationsResult<TObject>>({
     recommendations: [],
@@ -50,8 +50,8 @@ export function useRelatedProducts<TObject>({
       objectIDs,
       queryParameters,
       threshold,
-      experimental,
       transformItems: transformItemsRef.current,
+      ...props,
     };
 
     if (hasProvider && isContextClient) {
@@ -108,8 +108,8 @@ export function useRelatedProducts<TObject>({
     queryParameters,
     register,
     setStatus,
-    experimental,
     threshold,
+    props,
   ]);
 
   return {

--- a/packages/recommend-react/src/useRelatedProducts.ts
+++ b/packages/recommend-react/src/useRelatedProducts.ts
@@ -22,6 +22,9 @@ export function useRelatedProducts<TObject>({
   transformItems: userTransformItems = (x) => x,
   ...props
 }: UseRelatedProductsProps<TObject>) {
+  // @ts-expect-error used for internal experimental-personalization
+  const { region, userToken } = props;
+
   const [result, setResult] = useState<GetRecommendationsResult<TObject>>({
     recommendations: [],
   });
@@ -51,7 +54,6 @@ export function useRelatedProducts<TObject>({
       queryParameters,
       threshold,
       transformItems: transformItemsRef.current,
-      ...props,
     };
 
     if (hasProvider && isContextClient) {
@@ -90,6 +92,8 @@ export function useRelatedProducts<TObject>({
 
     setStatus('loading');
     getRelatedProducts({
+      region,
+      userToken,
       ...param,
       recommendClient: client,
     }).then((response) => {
@@ -109,7 +113,8 @@ export function useRelatedProducts<TObject>({
     register,
     setStatus,
     threshold,
-    props,
+    region,
+    userToken,
   ]);
 
   return {

--- a/packages/recommend-react/src/useTrendingItems.ts
+++ b/packages/recommend-react/src/useTrendingItems.ts
@@ -23,7 +23,9 @@ export function useTrendingItems<TObject>({
   facetValue,
   ...props
 }: UseTrendingItemsProps<TObject>) {
-  console.log('useTrendingItems', props);
+  // @ts-expect-error used for internal experimental-personalization
+  const { region, userToken } = props;
+
   const [result, setResult] = useState<GetRecommendationsResult<TObject>>({
     recommendations: [],
   });
@@ -54,7 +56,6 @@ export function useTrendingItems<TObject>({
       facetName,
       facetValue,
       transformItems: transformItemsRef.current,
-      ...props,
     };
 
     if (hasProvider && isContextClient) {
@@ -82,8 +83,9 @@ export function useTrendingItems<TObject>({
 
     setStatus('loading');
     getTrendingItems({
+      region,
+      userToken,
       ...param,
-      ...props,
       recommendClient: client,
       transformItems: transformItemsRef.current,
     }).then((response) => {
@@ -104,7 +106,8 @@ export function useTrendingItems<TObject>({
     hasProvider,
     isContextClient,
     register,
-    props,
+    region,
+    userToken,
   ]);
 
   return {

--- a/packages/recommend-react/src/useTrendingItems.ts
+++ b/packages/recommend-react/src/useTrendingItems.ts
@@ -21,7 +21,7 @@ export function useTrendingItems<TObject>({
   transformItems: userTransformItems = (x) => x,
   facetName,
   facetValue,
-  experimental,
+  ...props
 }: UseTrendingItemsProps<TObject>) {
   const [result, setResult] = useState<GetRecommendationsResult<TObject>>({
     recommendations: [],
@@ -53,6 +53,7 @@ export function useTrendingItems<TObject>({
       facetName,
       facetValue,
       transformItems: transformItemsRef.current,
+      ...props,
     };
 
     if (hasProvider && isContextClient) {
@@ -81,7 +82,7 @@ export function useTrendingItems<TObject>({
     setStatus('loading');
     getTrendingItems({
       ...param,
-      experimental,
+      ...props,
       recommendClient: client,
       transformItems: transformItemsRef.current,
     }).then((response) => {
@@ -102,7 +103,7 @@ export function useTrendingItems<TObject>({
     hasProvider,
     isContextClient,
     register,
-    experimental,
+    props,
   ]);
 
   return {

--- a/packages/recommend-react/src/useTrendingItems.ts
+++ b/packages/recommend-react/src/useTrendingItems.ts
@@ -23,6 +23,7 @@ export function useTrendingItems<TObject>({
   facetValue,
   ...props
 }: UseTrendingItemsProps<TObject>) {
+  console.log('useTrendingItems', props);
   const [result, setResult] = useState<GetRecommendationsResult<TObject>>({
     recommendations: [],
   });

--- a/scripts/rollup/config.js
+++ b/scripts/rollup/config.js
@@ -35,14 +35,16 @@ const plugins = [
 ];
 
 export function createRollupConfig(pkg) {
-  const sources = {};
+  const sources = {
+    [pkg['umd:main']]: pkg.source,
+  };
 
-  if (typeof pkg.source === 'string') {
-    sources[pkg['umd:main']] = pkg.source;
-  } else {
-    Object.entries(pkg.source).forEach(([key, source]) => {
-      sources[pkg[`umd:${key}`]] = source;
-    });
+  if (
+    pkg.name === '@algolia/recommend-js' ||
+    pkg.name === '@algolia/recommend-react'
+  ) {
+    sources['dist/umd/experimental-personalization/index.js'] =
+      'src/experimental-personalization/index.ts';
   }
 
   return Object.entries(sources).map(([file, source]) => {

--- a/scripts/rollup/config.js
+++ b/scripts/rollup/config.js
@@ -34,32 +34,41 @@ const plugins = [
   }),
 ];
 
-export function createRollupConfig(pkg) {
-  return {
-    input: pkg.source,
+export const createRollupConfig = (pkg) => {
+  const sources =
+    typeof pkg.source === 'string'
+      ? { [pkg['umd:main']]: pkg.source }
+      : Object.fromEntries(
+          Object.entries(pkg.source).map(([key, source]) => [pkg[key], source])
+        );
+
+  return Object.entries(sources).map(([file, source]) => ({
+    input: source,
     output: {
       banner: getBundleBanner(pkg),
-      dir: pkg['umd:main'],
+      file,
       format: 'umd',
       name: pkg.name,
       sourcemap: true,
     },
     plugins,
-  };
-}
+  }));
+};
 
 export function createRollupConfigForReact(pkg) {
-  const config = createRollupConfig(pkg);
+  const configs = createRollupConfig(pkg);
 
-  return {
-    ...config,
-    external: ['react', 'react-dom'],
-    output: {
-      ...config.output,
-      globals: {
-        react: 'React',
-        'react-dom': 'ReactDOM',
+  return configs.map((config) => {
+    return {
+      ...config,
+      external: ['react', 'react-dom'],
+      output: {
+        ...config.output,
+        globals: {
+          react: 'React',
+          'react-dom': 'ReactDOM',
+        },
       },
-    },
-  };
+    };
+  });
 }

--- a/scripts/rollup/config.js
+++ b/scripts/rollup/config.js
@@ -39,7 +39,7 @@ export function createRollupConfig(pkg) {
     input: pkg.source,
     output: {
       banner: getBundleBanner(pkg),
-      file: pkg['umd:main'],
+      dir: pkg['umd:main'],
       format: 'umd',
       name: pkg.name,
       sourcemap: true,

--- a/scripts/rollup/config.js
+++ b/scripts/rollup/config.js
@@ -34,26 +34,31 @@ const plugins = [
   }),
 ];
 
-export const createRollupConfig = (pkg) => {
-  const sources =
-    typeof pkg.source === 'string'
-      ? { [pkg['umd:main']]: pkg.source }
-      : Object.fromEntries(
-          Object.entries(pkg.source).map(([key, source]) => [pkg[key], source])
-        );
+export function createRollupConfig(pkg) {
+  const sources = {};
 
-  return Object.entries(sources).map(([file, source]) => ({
-    input: source,
-    output: {
-      banner: getBundleBanner(pkg),
-      file,
-      format: 'umd',
-      name: pkg.name,
-      sourcemap: true,
-    },
-    plugins,
-  }));
-};
+  if (typeof pkg.source === 'string') {
+    sources[pkg['umd:main']] = pkg.source;
+  } else {
+    Object.entries(pkg.source).forEach(([key, source]) => {
+      sources[pkg[`umd:${key}`]] = source;
+    });
+  }
+
+  return Object.entries(sources).map(([file, source]) => {
+    return {
+      input: source,
+      output: {
+        banner: getBundleBanner(pkg),
+        file,
+        format: 'umd',
+        name: pkg.name,
+        sourcemap: true,
+      },
+      plugins,
+    };
+  });
+}
 
 export function createRollupConfigForReact(pkg) {
   const configs = createRollupConfig(pkg);


### PR DESCRIPTION
Export `experimental-personalization` in `@algolia/recommend-js` & `@algolia/recommend-react` 

